### PR TITLE
Style fixes

### DIFF
--- a/firmware/tests/CAN_module/CAN_module_test.ino
+++ b/firmware/tests/CAN_module/CAN_module_test.ino
@@ -4,10 +4,10 @@
 
 
 
-#define CAN_1_CS 9              // chip select pin for DAC
+#define CAN_1_CS 9              // chip select pin for CAN1
 
 
-#define CAN_2_CS 10             // chip select pin for CAN
+#define CAN_2_CS 10             // chip select pin for CAN2
 
 
 #define CAN_BAUD ( CAN_500KBPS )

--- a/firmware/tests/dac_adc_diagnostics/dac_adc_diagnostics.ino
+++ b/firmware/tests/dac_adc_diagnostics/dac_adc_diagnostics.ino
@@ -146,7 +146,7 @@ void test_CAN_send( )
                                     0x00, 
                                     0x00 };
 
-    // send data:  id = 0x123, standrad frame, data len = 8, stmp: data buf
+    // send data:  id = 123, standard frame, data len = 8, stmp: data buf
     CAN.sendMsgBuf( 0x07B, 0, 8, canMsg ); 
     delay( 250 );
 }


### PR DESCRIPTION
Remove outdated and confusing comments. Add comments on things I found
confusing.

Replace hard-coded 0.48 and 0.2 with ZERO_PRESSURE and PRESSURE_STEP,
respectively.

Fix messed up #define of PSYNC_DEBUG_FLAG.