### PR TITLE
Fix pin mapping for brake module's right pressure sensor.

### DIFF
--- a/firmware/brake/kia_soul_ps/brake_control_module.ino
+++ b/firmware/brake/kia_soul_ps/brake_control_module.ino
@@ -488,7 +488,7 @@ Brakes::Brakes( byte sensorPLeft, byte sensorPRight, byte solenoidPinLeftA, byte
 // Instantiate objects 
 Accumulator accumulator( PIN_PACC, PIN_PUMP ); 
 SMC smc(PIN_PMC1, PIN_PMC2, PIN_SMC);
-Brakes brakes = Brakes( PIN_PFL, PIN_PFL, PIN_SLAFL, PIN_SLAFR, PIN_SLRFL, PIN_SLRFR);
+Brakes brakes = Brakes( PIN_PFL, PIN_PFR, PIN_SLAFL, PIN_SLAFR, PIN_SLRFL, PIN_SLRFR);
 
 
 


### PR DESCRIPTION
Previously, the left pin was used instead for both left and right sensors.