### PR TITLE
Add exception handling for build failure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,34 +1,42 @@
 #!groovy
 node('arduino') {
-  stage('Checkout') {
-    checkout([
-      $class: 'GitSCM',
-      branches: scm.branches,
-      extensions: scm.extensions + [[$class: 'CleanBeforeCheckout']],
-      userRemoteConfigs: scm.userRemoteConfigs
-    ])
-  }
-  stage('Build') {
-    parallel 'steering firmware': {
-      sh 'cd firmware/steering/kia_soul_ps && make'
-    }, 'throttle firmware': {
-      sh 'cd firmware/throttle/kia_soul_ps && make'
-    }, 'brake firmware': {
-      sh 'cd firmware/brake/kia_soul_ps && make'
-    }, 'CAN gateway firmware': {
-      sh 'cd firmware/can_gateway/kia_soul_ps && make'
+  try {
+    stage('Checkout') {
+      checkout([
+        $class: 'GitSCM',
+        branches: scm.branches,
+        extensions: scm.extensions + [[$class: 'CleanBeforeCheckout']],
+        userRemoteConfigs: scm.userRemoteConfigs
+      ])
     }
-    echo 'Build Complete!'
-  }
-  stage('Test') {
-    parallel 'unit tests': {
-      //sh 'make test'
-      echo 'Unit Tests Complete!'
-    }, 'acceptance tests': {
-      echo 'Acceptance Tests Complete!'
+    stage('Build') {
+      parallel 'steering firmware': {
+        sh 'cd firmware/steering/kia_soul_ps && make'
+      }, 'throttle firmware': {
+        sh 'cd firmware/throttle/kia_soul_ps && make'
+      }, 'brake firmware': {
+        sh 'cd firmware/brake/kia_soul_ps && make'
+      }, 'CAN gateway firmware': {
+        sh 'cd firmware/can_gateway/kia_soul_ps && make'
+      }
+      echo 'Build Complete!'
+    }
+    stage('Test') {
+      parallel 'unit tests': {
+        //sh 'make test'
+        echo 'Unit Tests Complete!'
+      }, 'acceptance tests': {
+        echo 'Acceptance Tests Complete!'
+      }
+    }
+    stage('Release') {
+      echo 'Release Package Created!'
     }
   }
-  stage('Release') {
-    echo 'Release Package Created!'
+  catch(Exception e) {
+    throw e;
+  }
+  finally {
+    deleteDir()
   }
 }


### PR DESCRIPTION
Prior to this commit, we did not have exception handling in place
for build failures.  This meant that the workspace was not getting
properly cleaned up on a failed build, so the build machines' storage
was getting clogged with workspaces from failed builds.  This
commit adds exception handling so that if the build fails in the
checkout or build stage, the workspace will be deleted.