### PR TITLE
Remove "pre-" from pre-order.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Once we have validated the boards we will be shipping the boards as a kit.
 Thanks to [Trey German](https://www.PolymorphicLabs.com) and [Macrofab](https://macrofab.com/) for help desiging the boards and getting them made.
 
 
-Click [Here](http://oscc.io) to pre-order your autonomy kit now.
+Click [Here](http://oscc.io) to order your autonomy kit now.
 
 Building and Installing Arduino Firmware
 ------------


### PR DESCRIPTION
Prior to this commit the README.md was still indicating that OSCC boards were in pre-order status, but the project has transitioned to the ready-to-order phase.  After this commit the README.md properly reflects the project's ordering status.