### PR TITLE
Bugfix/add common h

### DIFF
--- a/firmware/arduino_libraries/common/common.h
+++ b/firmware/arduino_libraries/common/common.h
@@ -1,0 +1,55 @@
+/************************************************************************/
+/* The MIT License (MIT)                                                */
+/* =====================                                                */
+/*                                                                      */
+/* Copyright (c) 2016 PolySync Technologies, Inc.  All Rights Reserved. */
+/*                                                                      */
+/* Permission is hereby granted, free of charge, to any person          */
+/* obtaining a copy of this software and associated documentation       */
+/* files (the “Software”), to deal in the Software without              */
+/* restriction, including without limitation the rights to use,         */
+/* copy, modify, merge, publish, distribute, sublicense, and/or sell    */
+/* copies of the Software, and to permit persons to whom the            */
+/* Software is furnished to do so, subject to the following             */
+/* conditions:                                                          */
+/*                                                                      */
+/* The above copyright notice and this permission notice shall be       */
+/* included in all copies or substantial portions of the Software.      */
+/*                                                                      */
+/* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,      */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES      */
+/* OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND             */
+/* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT          */
+/* HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,         */
+/* WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING         */
+/* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR        */
+/* OTHER DEALINGS IN THE SOFTWARE.                                      */
+/************************************************************************/
+
+/**
+ * @brief common.
+ *
+ * Holds high level macros which are common to most or all firmware projects.
+ *
+ */
+
+
+
+//
+#define CAN_BAUD (CAN_500KBPS)
+
+//
+#define SERIAL_BAUD (115200)
+
+//
+#define CAN_INIT_RETRY_DELAY (50)
+
+//
+#define GET_TIMESTAMP_MS() ((uint32_t) millis())
+
+//
+#define GET_TIMESTAMP_US() ((uint32_t) micros())
+
+//
+#define SLEEP_MS(x) delay(x)
+

--- a/firmware/brake/kia_soul_ps/brake_control_module.ino
+++ b/firmware/brake/kia_soul_ps/brake_control_module.ino
@@ -31,14 +31,8 @@
 #include <FiniteStateMachine.h>
 #include "mcp_can.h"
 #include "can_frame.h"
+#include "common.h"
 #include "control_protocol_can.h"
-
-#define PSYNC_DEBUG_FLAG
-
-// show us if debugging
-#ifdef PSYNC_DEBUG_FLAG
-#warning "PSYNC_DEBUG_FLAG defined"
-#endif
 
 
 
@@ -47,39 +41,22 @@
 // static global data
 // *****************************************************
 
-// chip select pin for CAN Shield
-#define CAN_CS 10
 
+#define PSYNC_DEBUG_FLAG
 
-//
-#define CAN_CONTROL_BAUD (CAN_500KBPS)
-
-
-//
-#define SERIAL_DEBUG_BAUD (115200)
-
-
-//
-#define CAN_INIT_RETRY_DELAY (50)
-
-
+// show us if debugging
 #ifdef PSYNC_DEBUG_FLAG
+    #warning "PSYNC_DEBUG_FLAG defined"
     #define DEBUG_PRINT(x)  Serial.println(x)
 #else
     #define DEBUG_PRINT(x)
 #endif
 
+// chip select pin for CAN Shield
+#define CAN_CS 10
 
 // ms
 #define PS_CTRL_RX_WARN_TIMEOUT (150)
-
-
-//
-#define GET_TIMESTAMP_MS() ((uint32_t) millis())
-
-
-//
-#define GET_TIMESTAMP_US() ((uint32_t) micros())
 
 
 
@@ -495,18 +472,13 @@ Brakes brakes = Brakes( PIN_PFL, PIN_PFL, PIN_SLAFL, PIN_SLAFR, PIN_SLRFL, PIN_S
 
 
 
+
 //
 static void init_serial( void )
 {
-    // Disable serial
-    Serial.end();
+    Serial.begin( SERIAL_BAUD );
 
-    // Init if debugging
-#ifdef PSYNC_DEBUG_FLAG
-    Serial.begin( SERIAL_DEBUG_BAUD );
-#endif
-
-    // Debug log
+    // debug log
     DEBUG_PRINT( "init_serial: pass" );
 }
 
@@ -515,7 +487,7 @@ static void init_serial( void )
 static void init_can( void )
 {
     // Wait until we have initialized
-    while( CAN.begin(CAN_CONTROL_BAUD) != CAN_OK )
+    while( CAN.begin( CAN_BAUD ) != CAN_OK )
     {
         // wait a little
         delay( CAN_INIT_RETRY_DELAY );

--- a/firmware/can_gateway/kia_soul_ps/can_gateway.ino
+++ b/firmware/can_gateway/kia_soul_ps/can_gateway.ino
@@ -48,15 +48,8 @@
 #include "mcp_can.h"
 #include "can_frame.h"
 #include "kia_obd_can.h"
+#include "common.h"
 #include "control_protocol_can.h"
-
-
-
-
-// show us if debugging
-#ifdef PSYNC_DEBUG_FLAG
-#warning "PSYNC_DEBUG_FLAG defined"
-#endif
 
 
 
@@ -64,6 +57,18 @@
 // *****************************************************
 // static global types/macros
 // *****************************************************
+
+
+#define PSYNC_DEBUG_FLAG
+
+// show us if debugging
+#ifdef PSYNC_DEBUG_FLAG
+    #warning "PSYNC_DEBUG_FLAG defined"
+    #define DEBUG_PRINT(x)  Serial.println(x)
+#else
+    #define DEBUG_PRINT(x)
+#endif
+
 
 //
 #define PSVC_VGM_NODE_ID (0x10)
@@ -90,47 +95,11 @@
 
 
 //
-#define CAN_OBD_BAUD (CAN_500KBPS)
-
-
-//
-#define CAN_CONTROL_BAUD (CAN_500KBPS)
-
-
-//
-#define SERIAL_DEBUG_BAUD (115200)
-
-
-//
-#define CAN_INIT_RETRY_DELAY (50)
-
-
-//
-#ifdef PSYNC_DEBUG_FLAG
-    #define DEBUG_PRINT(x)  Serial.println(x)
-#else
-    #define DEBUG_PRINT(x)
-#endif
-
-
-//
 #define STATUS_LED_ON() digitalWrite(PIN_STATUS_LED, HIGH);
 
 
 //
 #define STATUS_LED_OFF() digitalWrite(PIN_STATUS_LED, LOW);
-
-
-//
-#define GET_TIMESTAMP_MS() ((uint32_t) millis())
-
-
-//
-#define GET_TIMESTAMP_US() ((uint32_t) micros())
-
-
-//
-#define SLEEP_MS(x) delay(x)
 
 
 //
@@ -254,7 +223,7 @@ static void init_serial( void )
 
     // init if debugging
 #ifdef PSYNC_DEBUG_FLAG
-    Serial.begin( SERIAL_DEBUG_BAUD );
+    Serial.begin( SERIAL_BAUD );
 #endif
 
     // debug log
@@ -267,7 +236,7 @@ static void init_obd_can( void )
 {
     // wait until we have initialized
     // watchdog will reset if we take too long
-    while( obd_can.begin(CAN_OBD_BAUD) != CAN_OK )
+    while( obd_can.begin( CAN_BAUD ) != CAN_OK )
     {
         // wait a little
         delay( CAN_INIT_RETRY_DELAY );
@@ -283,7 +252,7 @@ static void init_control_can( void )
 {
     // wait until we have initialized
     // watchdog will reset if we take too long
-    while( control_can.begin(CAN_CONTROL_BAUD) != CAN_OK )
+    while( control_can.begin( CAN_BAUD ) != CAN_OK )
     {
         // wait a little
         delay( CAN_INIT_RETRY_DELAY );

--- a/firmware/steering/kia_soul_ps/steering_control_module.ino
+++ b/firmware/steering/kia_soul_ps/steering_control_module.ino
@@ -30,6 +30,7 @@
 #include "control_protocol_can.h"
 #include "current_control_state.h"
 #include "PID.h"
+#include "common.h"
 #include "DAC_MCP49xx.h"
 
 
@@ -39,10 +40,12 @@
 // static global types/macros
 // *****************************************************
 
-#define PSYNC_DEBUG_FLAG true
 
-//
+#define PSYNC_DEBUG_FLAG
+
+// show us if debugging
 #ifdef PSYNC_DEBUG_FLAG
+    #warning "PSYNC_DEBUG_FLAG defined"
     #define DEBUG_PRINT(x)  Serial.println(x)
 #else
     #define DEBUG_PRINT(x)
@@ -51,19 +54,8 @@
 // Set CAN_CS to pin 10 for CAN
 #define CAN_CS 10
 
-#define CAN_BAUD ( CAN_500KBPS )
-
-//
-#define SERIAL_BAUD (115200)
-
-//
-#define CAN_INIT_RETRY_DELAY (50)
-
-//
-#define GET_TIMESTAMP_MS() ((uint32_t) millis())
-
 // ms
-#define PS_CTRL_RX_WARN_TIMEOUT (200) //(50)
+#define PS_CTRL_RX_WARN_TIMEOUT (200)
 
 // Set up pins for interface with the DAC (MCP4922)
 
@@ -132,7 +124,7 @@ int total = 0;                  // the running total
 // corrects for overflow condition
 static void get_update_time_delta_ms(
 		const uint32_t time_in,
-		const uint32_t last_update_time_ms,
+    	const uint32_t last_update_time_ms,
 		uint32_t * const delta_out )
 {
     // check for overflow
@@ -462,15 +454,15 @@ static void check_rx_timeouts( void )
 
     // get time since last receive
     get_update_time_delta_ms( 
-			rx_frame_ps_ctrl_steering_command.timestamp, 
+			rx_frame_ps_ctrl_steering_command.timestamp,
 			GET_TIMESTAMP_MS(), 
 			&delta );
 
     // check rx timeout
-    if( delta >= PS_CTRL_RX_WARN_TIMEOUT ) 
+    if( delta >= PS_CTRL_RX_WARN_TIMEOUT )
     {
         // disable control from the PolySync interface
-        if( current_ctrl_state.control_enabled ) 
+        if( current_ctrl_state.control_enabled )
         {
             disableControl();
         }

--- a/firmware/tests/CAN_module/CAN_module_test.ino
+++ b/firmware/tests/CAN_module/CAN_module_test.ino
@@ -1,6 +1,7 @@
 #include "SPI.h"
 #include "mcp_can.h"
 #include "can_frame.h"
+#include "common.h"
 
 
 
@@ -8,15 +9,6 @@
 
 
 #define CAN_2_CS 10             // chip select pin for CAN2
-
-
-#define CAN_BAUD ( CAN_500KBPS )
-
-
-#define SERIAL_BAUD (115200)
-
-
-#define CAN_INIT_RETRY_DELAY (50)
 
 
 static MCP_CAN CAN_1( CAN_1_CS );

--- a/firmware/tests/brake_bench/brake_controller_r0_test.ino
+++ b/firmware/tests/brake_bench/brake_controller_r0_test.ino
@@ -1,15 +1,12 @@
 #include "SPI.h"
 #include "mcp_can.h"
 #include "can_frame.h"
+#include "common.h"
+
+
+
 
 #define CAN_CS 53                          // chip select pin for CAN Shield
-
-#define CAN_BAUD (CAN_500KBPS)
-
-#define SERIAL_BAUD (115200)
-
-#define CAN_INIT_RETRY_DELAY (50)
-
 
 // construct the CAN shield object
 MCP_CAN CAN(CAN_CS);                                    // Set CS pin for the CAN shield

--- a/firmware/tests/brake_controller/brake_controller_r0_test.ino
+++ b/firmware/tests/brake_controller/brake_controller_r0_test.ino
@@ -12,15 +12,8 @@
 #include <FiniteStateMachine.h>
 #include "mcp_can.h"
 #include "can_frame.h"
+#include "common.h"
 #include "control_protocol_can.h"
-
-
-#define PSYNC_DEBUG_FLAG = true;
-
-// show us if debugging
-#ifdef PSYNC_DEBUG_FLAG
-#warning "PSYNC_DEBUG_FLAG defined"
-#endif
 
 
 
@@ -29,35 +22,20 @@
 // static global data
 // *****************************************************
 
-// chip select pin for CAN Shield
-#define CAN_CS 53
 
+#define PSYNC_DEBUG_FLAG
 
-//
-#define CAN_CONTROL_BAUD (CAN_500KBPS)
-
-
-//
-#define SERIAL_DEBUG_BAUD (115200)
-
-
-//
-#define CAN_INIT_RETRY_DELAY (50)
-
-
+// show us if debugging
 #ifdef PSYNC_DEBUG_FLAG
+    #warning "PSYNC_DEBUG_FLAG defined"
     #define DEBUG_PRINT(x)  Serial.println(x)
 #else
     #define DEBUG_PRINT(x)
 #endif
 
 
-//
-#define GET_TIMESTAMP_MS() ((uint32_t) millis())
-
-
-//
-#define GET_TIMESTAMP_US() ((uint32_t) micros())
+// chip select pin for CAN Shield
+#define CAN_CS 53
 
 
 
@@ -456,7 +434,7 @@ static void init_serial( void )
 
     // Init if debugging
 #ifdef PSYNC_DEBUG_FLAG
-    Serial.begin( SERIAL_DEBUG_BAUD );
+    Serial.begin( SERIAL_BAUD );
 #endif
 
     // Debug log
@@ -468,7 +446,7 @@ static void init_serial( void )
 static void init_can( void )
 {
     // Wait until we have initialized
-    while( CAN.begin(CAN_CONTROL_BAUD) != CAN_OK )
+    while( CAN.begin(CAN_BAUD) != CAN_OK )
     {
         // wait a little
         delay( CAN_INIT_RETRY_DELAY );

--- a/firmware/tests/dac_adc_diagnostics/dac_adc_diagnostics.ino
+++ b/firmware/tests/dac_adc_diagnostics/dac_adc_diagnostics.ino
@@ -2,6 +2,8 @@
 #include "mcp_can.h"
 #include "can_frame.h"
 #include "DAC_MCP49xx.h"
+#include "common.h"
+
 
 
 
@@ -18,14 +20,6 @@
 #define DAC_CS 9              // chip select pin for DAC
 
 #define CAN_CS 10             // chip select pin for CAN
-
-
-
-#define CAN_BAUD ( CAN_500KBPS )
-
-#define SERIAL_BAUD ( 115200 )
-
-#define CAN_INIT_RETRY_DELAY ( 50 )
 
 
 DAC_MCP49xx dac( DAC_MCP49xx::MCP4922, 9 ); // DAC model, SS pin, LDAC pin

--- a/firmware/tests/steering_controller/steering_controller_r0_test.ino
+++ b/firmware/tests/steering_controller/steering_controller_r0_test.ino
@@ -2,6 +2,7 @@
 #include "mcp_can.h"
 #include "can_frame.h"
 #include "DAC_MCP49xx.h"
+#include "common.h"
 
 
 
@@ -18,14 +19,6 @@
 #define DAC_CS 9              // chip select pin for DAC
 
 #define CAN_CS 10             // chip select pin for CAN
-
-
-
-#define CAN_BAUD ( CAN_500KBPS )
-
-#define SERIAL_BAUD ( 115200 )
-
-#define CAN_INIT_RETRY_DELAY ( 50 )
 
 
 DAC_MCP49xx dac( DAC_MCP49xx::MCP4922, 9 ); // DAC model, SS pin, LDAC pin

--- a/firmware/throttle/kia_soul_ps/throttle_control_module.ino
+++ b/firmware/throttle/kia_soul_ps/throttle_control_module.ino
@@ -29,6 +29,7 @@
 #include "mcp_can.h"
 #include "can_frame.h"
 #include "control_protocol_can.h"
+#include "common.h"
 #include "DAC_MCP49xx.h"
 
 
@@ -41,8 +42,9 @@
 
 #define PSYNC_DEBUG_FLAG
 
-//
+// show us if debugging
 #ifdef PSYNC_DEBUG_FLAG
+    #warning "PSYNC_DEBUG_FLAG defined"
     #define DEBUG_PRINT(x)  Serial.println(x)
 #else
     #define DEBUG_PRINT(x)
@@ -51,19 +53,8 @@
 // set CAN_CS to pin 10 for CAN 
 #define CAN_CS 10
 
-#define CAN_BAUD (CAN_500KBPS)
-
-//
-#define SERIAL_DEBUG_BAUD (115200)
-
-//
-#define CAN_INIT_RETRY_DELAY (50)
-
 // ms
 #define PS_CTRL_RX_WARN_TIMEOUT (250)
-
-//
-#define GET_TIMESTAMP_MS() ((uint32_t) millis())
 
 // set up pins for interface with DAC (MCP4922)
 
@@ -157,10 +148,15 @@ static void get_update_time_ms(
 }
 
 
-static void init_serial( void ) 
+//
+static void init_serial( void )
 {
-    Serial.begin(115200);
+    Serial.begin( SERIAL_BAUD );
+
+    // debug log
+    DEBUG_PRINT( "init_serial: pass" );
 }
+
 
 static void init_can ( void ) 
 {


### PR DESCRIPTION
Prior to this pull request the OSCC lacked a central header file to dump common macros included in multiple firmware files. This pull request creates this "common.h" file and updates the dependencies of any affected firmware/test files to reflect this change. 