### PR TITLE
Add exponential instead of linear joystick mapping

### DIFF
--- a/control/joystick_commander/Makefile
+++ b/control/joystick_commander/Makefile
@@ -57,7 +57,7 @@ INCLUDE += -Iinclude -I$(LIB_HOME)
 
 # add node template library, must be first
 # add util library last, let path be found
-LIBS := $(LIBS) `pkg-config --libs sdl2` -lcanlib
+LIBS := $(LIBS) `pkg-config --libs sdl2` -lcanlib -lm
 
 # all builds directories and target
 all: dirs $(TARGET)

--- a/control/joystick_commander/include/joystick.h
+++ b/control/joystick_commander/include/joystick.h
@@ -249,6 +249,22 @@ double jstick_normalize_axis_position(
         const double range_max );
 
 
+/**
+ * @brief Map trigger value from one range to another.
+ *
+ * @param [in] position Input value to map.
+ * @param [in] range_min Output minimum range.
+ * @param [in] range_max Output maximum range.
+ *
+ * @return position mapped to the range of min:max.
+ *
+ */
+double jstick_normalize_trigger_position(
+        const int position,
+        const double range_min,
+        const double range_max );
+
+
 
 
 #endif	/* JOYSTICK_H */

--- a/control/joystick_commander/src/commander.c
+++ b/control/joystick_commander/src/commander.c
@@ -210,10 +210,11 @@ static int get_brake_setpoint(
             JSTICK_AXIS_BRAKE,
             &axis_position );
 
+    // if succeeded
     if( ret == NOERR )
     {       
         // set brake set point - scale to 0:max
-        (*brake) = jstick_normalize_axis_position(
+        (*brake) = jstick_normalize_trigger_position(
                 axis_position,
                 0.0,
                 MAX_BRAKE_PEDAL );
@@ -243,7 +244,7 @@ static int get_throttle_setpoint(
     if( ret == NOERR )
     {
         // set throttle set point - scale to 0:max
-        (*throttle) = jstick_normalize_axis_position(
+        (*throttle) = jstick_normalize_trigger_position(
                 axis_position,
                 0.0,
                 MAX_THROTTLE_PEDAL );
@@ -263,11 +264,14 @@ static int get_steering_setpoint(
     int axis_position = 0;
 
 
+    // read axis position
     ret = jstick_get_axis(
             jstick,
             JSTICK_AXIS_STEER,
             &axis_position );
+    
 
+    // if succeeded
     if( ret == NOERR )
     {
         // set steering wheel angle set point - scale to max:min

--- a/control/joystick_commander/src/commander.c
+++ b/control/joystick_commander/src/commander.c
@@ -278,8 +278,8 @@ static int get_steering_setpoint(
         // note that this is inverting the sign of the joystick axis
         (*angle) = jstick_normalize_axis_position(
                 axis_position,
-                MAX_STEERING_WHEEL_ANGLE,
-                MIN_STEERING_WHEEL_ANGLE );
+                MIN_STEERING_WHEEL_ANGLE,
+                MAX_STEERING_WHEEL_ANGLE );
     }
 
 

--- a/control/joystick_commander/src/joystick.c
+++ b/control/joystick_commander/src/joystick.c
@@ -39,6 +39,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
+#include <math.h>
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_joystick.h>
 
@@ -347,12 +348,67 @@ double jstick_normalize_axis_position(
         const double range_max )
 {
     const double s = (double) position;
+    
+    double a1;
+    double a2;
+    double b1;
+    double b2;
+    
+    if( position < 0 )
+    {
+        a1 = 0;
+        a2 = JOYSTICK_AXIS_POSITION_MIN;
+        b1 = 0;
+        b2 = range_min;
+    }
+    else
+    {
+        a1 = JOYSTICK_AXIS_POSITION_MAX;
+        a2 = 0;
+        b1 = range_max;
+        b2 = 0;
+    }
+    
+    const double x1 = 1.0; // cannot include zero in range
+    const double y1 = 1.0; // cannot include zero in range
+    const double x2 = a2 - a1 + 1.0; // add one to make sure the range doesn't include zero
+    const double y2 = b2 - b1 + 1.0; // add one to make sure the range doesn't include zero
+    
+    const double b = log( y1 / y2 )/( x1 - x2 );
+    const double a = y1 / exp( b * x1 );
+    
+    double result = a * exp( b * (position - a1 + 1.0) );
+    result = result + b1 - 1.0; // normalize back to correct range
+    
+    // map value s in the range of a1 and a2, to t(return) in the range b1 and b2, exponential
+    return result;
+}
+
+
+//
+double jstick_normalize_trigger_position(
+        const int position,
+        const double range_min,
+        const double range_max )
+{
+    const double s = (double) position;
     const double a1 = (double) JOYSTICK_AXIS_POSITION_MIN;
     const double a2 = (double) JOYSTICK_AXIS_POSITION_MAX;
+    
     const double b1 = range_min;
     const double b2 = range_max;
-
-
-    // map value s in the range of a1 and a2, to t(return) in the range b1 and b2, linear
-    return b1 + (s-a1) * (b2-b1) / (a2-a1);
+    
+    const double x1 = 1.0; // cannot include zero in range
+    const double y1 = 1.0; // cannot include zero in range
+    const double x2 = a2 - a1 + 1.0; // add one to make sure the range doesn't include zero
+    const double y2 = b2 - b1 + 1.0; // add one to make sure the range doesn't include zero
+    
+    const double b = log( y1 / y2 )/( x1 - x2 );
+    const double a = y1 / exp( b * x1 );
+    
+    double result = a * exp( b * (position - a1 + 1.0) );
+    result = result + b1 - 1.0; // normalize back to correct range
+    
+    // map value s in the range of a1 and a2, to t(return) in the range b1 and b2, exponential
+    return result;
 }

--- a/control/joystick_commander/src/joystick.c
+++ b/control/joystick_commander/src/joystick.c
@@ -342,33 +342,13 @@ int jstick_get_button(
 
 
 //
-double jstick_normalize_axis_position(
-        const int position,
-        const double range_min,
-        const double range_max )
+double jstick_calc_log_range( 
+        double a1, 
+        double a2, 
+        double b1, 
+        double b2, 
+        double position )
 {
-    const double s = (double) position;
-    
-    double a1;
-    double a2;
-    double b1;
-    double b2;
-    
-    if( position < 0 )
-    {
-        a1 = 0;
-        a2 = JOYSTICK_AXIS_POSITION_MIN;
-        b1 = 0;
-        b2 = range_min;
-    }
-    else
-    {
-        a1 = JOYSTICK_AXIS_POSITION_MAX;
-        a2 = 0;
-        b1 = range_max;
-        b2 = 0;
-    }
-    
     const double x1 = 1.0; // cannot include zero in range
     const double y1 = 1.0; // cannot include zero in range
     const double x2 = a2 - a1 + 1.0; // add one to make sure the range doesn't include zero
@@ -378,10 +358,37 @@ double jstick_normalize_axis_position(
     const double a = y1 / exp( b * x1 );
     
     double result = a * exp( b * (position - a1 + 1.0) );
-    result = result + b1 - 1.0; // normalize back to correct range
+    return result + b1 - 1.0; // normalize back to correct range
+}
+
+
+//
+double jstick_normalize_axis_position(
+        const int position,
+        const double range_min,
+        const double range_max )
+{
+    const double s = (double) position;
+    
+    double a1, a2, b1, b2;
+    
+    if( position < 0 )
+    {
+        a1 = 0;
+        a2 = JOYSTICK_AXIS_POSITION_MIN;
+        b1 = 0;
+        b2 = range_max;
+    }
+    else
+    {
+        a1 = JOYSTICK_AXIS_POSITION_MAX;
+        a2 = 0;
+        b1 = range_min;
+        b2 = 0;
+    }
     
     // map value s in the range of a1 and a2, to t(return) in the range b1 and b2, exponential
-    return result;
+    return jstick_calc_log_range( a1, a2, b1, b2, s );
 }
 
 
@@ -398,17 +405,5 @@ double jstick_normalize_trigger_position(
     const double b1 = range_min;
     const double b2 = range_max;
     
-    const double x1 = 1.0; // cannot include zero in range
-    const double y1 = 1.0; // cannot include zero in range
-    const double x2 = a2 - a1 + 1.0; // add one to make sure the range doesn't include zero
-    const double y2 = b2 - b1 + 1.0; // add one to make sure the range doesn't include zero
-    
-    const double b = log( y1 / y2 )/( x1 - x2 );
-    const double a = y1 / exp( b * x1 );
-    
-    double result = a * exp( b * (position - a1 + 1.0) );
-    result = result + b1 - 1.0; // normalize back to correct range
-    
-    // map value s in the range of a1 and a2, to t(return) in the range b1 and b2, exponential
-    return result;
+    return jstick_calc_log_range( a1, a2, b1, b2, s );
 }


### PR DESCRIPTION
Prior to this commit the joystick/trigger position was mapped linearlly to throttle, steering and brake. This caused abrupt changes in these control values in the lower ranges of the joystick/trigger motion. This commit changes this mapping to an exponential relationship, smoothing the control repsonse out.