### PR TITLE
fix/break-brake-check

### DIFF
--- a/control/joystick_commander/src/commander.c
+++ b/control/joystick_commander/src/commander.c
@@ -212,7 +212,7 @@ static int get_brake_setpoint(
 
     // if succeeded
     if( ret == NOERR )
-    {       
+    {
         // set brake set point - scale to 0:max
         (*brake) = jstick_normalize_trigger_position(
                 axis_position,
@@ -269,7 +269,7 @@ static int get_steering_setpoint(
             jstick,
             JSTICK_AXIS_STEER,
             &axis_position );
-    
+
 
     // if succeeded
     if( ret == NOERR )
@@ -357,11 +357,11 @@ static int publish_disable_brake_command(
     if( ret == NOERR )
     {
         msg->pedal_command = (uint16_t) 0.0;
-        
+
         msg->enabled = 0;
     }
-    
-    printf( "break: %d %d\n", msg->enabled, msg->pedal_command );
+
+    printf( "brake: %d %d\n", msg->enabled, msg->pedal_command );
 
     if( ret == NOERR )
     {
@@ -383,10 +383,10 @@ static int publish_disable_throttle_command(
     if( ret == NOERR )
     {
         msg->pedal_command = (uint16_t) 0.0;
-        
+
         msg->enabled = 0;
     }
-    
+
     printf( "throttle: %d %d\n", msg->enabled, msg->pedal_command );
 
     if( ret == NOERR )
@@ -417,12 +417,12 @@ static int publish_disable_steering_command(
     if( ret == NOERR )
     {
         msg->steering_wheel_angle_command = (int16_t) 0.0;
-        
+
         msg->steering_wheel_max_velocity = (uint8_t) constrained_rate;
-        
+
         msg->enabled = 0;
     }
-    
+
     printf( "steering: %d %d %d\n", msg->enabled, msg->steering_wheel_angle_command, msg->steering_wheel_max_velocity );
 
     if( ret == NOERR )
@@ -447,7 +447,7 @@ static int publish_brake_command(
     ret = get_brake_setpoint(
             jstick,
             &brake_setpoint );
-    
+
     // Redundant, but better safe then sorry
     const float normalized_value = (float) m_constrain(
             (float) brake_setpoint,
@@ -463,8 +463,8 @@ static int publish_brake_command(
     {
         msg->pedal_command = (uint16_t) constrained_value;
     }
-    
-    printf( "break: %d %d\n", msg->enabled, msg->pedal_command );
+
+    printf( "brake: %d %d\n", msg->enabled, msg->pedal_command );
 
     if( ret == NOERR )
     {
@@ -503,7 +503,7 @@ static int publish_throttle_command(
             throttle_setpoint = 0.0;
         }
     }
-    
+
     // Redundant, but better safe then sorry
     const float normalized_value = (float) m_constrain(
             (float) throttle_setpoint,
@@ -519,7 +519,7 @@ static int publish_throttle_command(
     {
         msg->pedal_command = (uint16_t) constrained_value;
     }
-    
+
     printf( "throttle: %d %d\n", msg->enabled, msg->pedal_command );
 
     if( ret == NOERR )
@@ -545,7 +545,7 @@ static int publish_steering_command(
     ret = get_steering_setpoint(
             jstick,
             &steering_setpoint );
-    
+
     const float angle_degrees = (float) m_degrees(
             (float) steering_setpoint );
 
@@ -565,10 +565,10 @@ static int publish_steering_command(
     if( ret == NOERR )
     {
         msg->steering_wheel_angle_command = (int16_t) constrained_angle;
-        
+
         msg->steering_wheel_max_velocity = (uint8_t) constrained_rate;
     }
-    
+
     printf( "steering: %d %d %d\n", msg->enabled, msg->steering_wheel_angle_command, msg->steering_wheel_max_velocity );
 
     if( ret == NOERR )
@@ -785,9 +785,9 @@ int commander_enable_controls(
         if( ret == NOERR )
         {
             commander->messages.brake_cmd.enabled = 1;
-            
+
             commander->messages.steering_cmd.enabled = 1;
-            
+
             commander->messages.throttle_cmd.enabled = 1;
         }
     }
@@ -850,7 +850,7 @@ int commander_update(
     if( (disable_button_pressed != 0) || (commander->driver_override == 1) )
     {
         ret = commander_disable_controls( commander );
-        
+
         commander->driver_override = 0;
     }
     else if( enable_button_pressed != 0 )

--- a/firmware/brake/kia_soul_ps/brake_control_module.ino
+++ b/firmware/brake/kia_soul_ps/brake_control_module.ino
@@ -99,18 +99,18 @@ static void get_update_time_delta_ms(
 {
     // check for overflow
     if( last_update_time_ms < time_in )
-    {   
+    {
 		// time remainder, prior to the overflow
 		(*delta_out) = (UINT32_MAX - time_in);
-        
+
         // add time since zero
         (*delta_out) += last_update_time_ms;
-    }   
+    }
     else
-    {   
+    {
         // normal delta
         (*delta_out) = ( last_update_time_ms - time_in );
-    }   
+    }
 }
 
 
@@ -136,7 +136,7 @@ static void get_update_time_ms(
 }
 
 
-// MOSFET pin (digital) definitions ( MOSFETs control the solenoids ) 
+// MOSFET pin (digital) definitions ( MOSFETs control the solenoids )
 // pins are not perfectly sequential because the clock frequency of certain pins is different.
 // Duty cycles of pins 3 and 5 controlled by timer 3 (TCCR3B)
 const byte PIN_SLAFL = 3;      // front left actuation
@@ -150,15 +150,15 @@ const byte PIN_PUMP = 9;     // accumulator pump motor
 
 
 // brake spoofer relay pin definitions
-const byte PIN_BREAK_SWITCH_1 = 48;
-const byte PIN_BREAK_SWITCH_2 = 49;
+const byte PIN_BRAKE_SWITCH_1 = 48;
+const byte PIN_BRAKE_SWITCH_2 = 49;
 
 
 // sensor pin (analog) definitions
 const byte PIN_PACC = 9;       // pressure accumulator sensor
 const byte PIN_PMC1 = 10;      // pressure master cylinder sensor 1
 const byte PIN_PMC2 = 11;      // pressure master cylinder sensor 2
-const byte PIN_PRL = 12;       // pressure rear left sensor 
+const byte PIN_PRL = 12;       // pressure rear left sensor
 const byte PIN_PFR = 13;       // pressure front right sensor
 const byte PIN_PFL = 14;       // pressure front left sensor
 const byte PIN_PRR = 15;       // pressure rear right sensor
@@ -168,11 +168,11 @@ const byte PIN_PRR = 15;       // pressure rear right sensor
 const double ZERO_PRESSURE = 0.48;        // The voltage the sensors read when no pressure is present
 const double PRESSURE_STEP = 0.2;         // The amount that the 'a' and 'd' commands change the
                                           // voltage each time they are pressed.
-const double MIN_PACC = 2.3;              // minumum accumulator pressure to maintain 
+const double MIN_PACC = 2.3;              // minumum accumulator pressure to maintain
 const double MAX_PACC = 2.4;              // max accumulator pressure to maintain
 const double PEDAL_THRESH = 0.5;          // Pressure for pedal interference
 
-int SLADutyMax, 
+int SLADutyMax,
     SLADutyMin,
     SLRDutyMax,
     SLRDutyMin;
@@ -185,8 +185,8 @@ double pressure_req,
 
 uint8_t incomingSerialByte;
 
-int deltaT=10, 
-    currMicros, 
+int deltaT=10,
+    currMicros,
     lastMicros = 0;
 
 unsigned long previousMillis=0;
@@ -204,11 +204,11 @@ int local_override = 0;
 
 // initialize states
 State Wait = State(waitEnter, waitUpdate, waitExit);        // Wait for brake instructions
-State Brake = State(brakeEnter, brakeUpdate, brakeExit);    // Control braking 
+State Brake = State(brakeEnter, brakeUpdate, brakeExit);    // Control braking
 
 
 // initialize state machine, start in state: Wait
-FSM brakeStateMachine = FSM(Wait);     
+FSM brakeStateMachine = FSM(Wait);
 
 
 int calculateSLADutyCycle(float pre) {
@@ -248,34 +248,34 @@ struct Accumulator {
     byte _controlPin = 99;
     Accumulator( byte sensorP, byte relayP );
 
-    void updatePressure() 
+    void updatePressure()
     {
     }
-    
 
-    // turn relay on or off 
-    void pumpOn() 
+
+    // turn relay on or off
+    void pumpOn()
     {
       digitalWrite(_controlPin, HIGH);
     }
 
-    
-    void pumpOff() 
+
+    void pumpOff()
     {
       digitalWrite(_controlPin, LOW);
     }
 
     // maintain accumulator pressure
-    void maintainPressure() 
+    void maintainPressure()
     {
       _pressure = convertToVoltage(analogRead(_sensorPin));
 
-      if( _pressure < MIN_PACC ) 
+      if( _pressure < MIN_PACC )
       {
           pumpOn();
       }
 
-      if( _pressure > MAX_PACC ) 
+      if( _pressure > MAX_PACC )
       {
           pumpOff();
       }
@@ -286,7 +286,7 @@ struct Accumulator {
 
 
 // accumulator constructor
-Accumulator::Accumulator( byte sensorPin, byte controlPin ) 
+Accumulator::Accumulator( byte sensorPin, byte controlPin )
 {
   _sensorPin = sensorPin;
   _controlPin = controlPin;
@@ -320,7 +320,7 @@ struct SMC {
 
         // if current pedal pressure is greater than limit (because of
         // driver override by pressing the brake pedal), disable.
-        if (_pressure1 > PEDAL_THRESH || _pressure2 > PEDAL_THRESH ) 
+        if (_pressure1 > PEDAL_THRESH || _pressure2 > PEDAL_THRESH )
         {
             DEBUG_PRINT("Brake Pedal Detected");
             pressure_req = ZERO_PRESSURE;
@@ -333,12 +333,12 @@ struct SMC {
         }
     }
 
-    void solenoidsClose() 
+    void solenoidsClose()
     {
         analogWrite( _controlPin, 255 );
     }
 
-    void solenoidsOpen() 
+    void solenoidsOpen()
     {
         analogWrite( _controlPin, 0 );
     }
@@ -347,7 +347,7 @@ struct SMC {
 
 
 
-SMC::SMC( byte sensor1Pin, byte sensor2Pin, byte controlPin ) 
+SMC::SMC( byte sensor1Pin, byte sensor2Pin, byte controlPin )
 {
   _sensor1Pin = sensor1Pin;
   _sensor2Pin = sensor2Pin;
@@ -372,14 +372,14 @@ struct Brakes {
     byte _solenoidPinLeftR = 99;          // pin associated with MOSFET, associated with actuation solenoid
     byte _solenoidPinRightR = 99;         // pin associated with MOSFET, associated with return solenoid
     bool _increasingPressure = false;     // used to track if pressure should be increasing
-    bool _decreasingPressure = false;     // used to track if pressure should be decreasing 
-    unsigned long _previousMillis = 0;    // will store last time solenoid was updated 
+    bool _decreasingPressure = false;     // used to track if pressure should be decreasing
+    unsigned long _previousMillis = 0;    // will store last time solenoid was updated
 
 
     Brakes( byte sensorPinLeft, byte sensorPinRight, byte solenoidPinLeftA, byte solenoidPinRightA, byte solenoidPinLeftR, byte solenoidPinRightR );
 
 
-    void depowerSolenoids() 
+    void depowerSolenoids()
     {
       analogWrite(_solenoidPinLeftA, 0);
       analogWrite(_solenoidPinRightA, 0);
@@ -390,14 +390,14 @@ struct Brakes {
 
 
     // fill pressure
-    void powerSLA(int scaler) 
+    void powerSLA(int scaler)
     {
         analogWrite( _solenoidPinLeftA, scaler );
         analogWrite( _solenoidPinRightA, scaler );
     }
 
-    
-    void depowerSLA() 
+
+    void depowerSLA()
     {
         analogWrite( _solenoidPinLeftA, 0 );
         analogWrite( _solenoidPinRightA, 0 );
@@ -405,22 +405,22 @@ struct Brakes {
 
 
     // spill pressure
-    void powerSLR(int scaler) 
+    void powerSLR(int scaler)
     {
         analogWrite( _solenoidPinLeftR, scaler );
         analogWrite( _solenoidPinRightR, scaler );
     }
 
-    
-    void depowerSLR() 
+
+    void depowerSLR()
     {
         digitalWrite( _solenoidPinLeftR, LOW );
         digitalWrite( _solenoidPinRightR, LOW );
     }
 
 
-    // take a pressure reading 
-    void updatePressure() 
+    // take a pressure reading
+    void updatePressure()
     {
       _pressureLeft = convertToVoltage( analogRead(_sensorPinLeft) );
       _pressureRight = convertToVoltage( analogRead(_sensorPinRight) );
@@ -453,8 +453,8 @@ Brakes::Brakes( byte sensorPLeft, byte sensorPRight, byte solenoidPinLeftA, byte
 
 
 
-// Instantiate objects 
-Accumulator accumulator( PIN_PACC, PIN_PUMP ); 
+// Instantiate objects
+Accumulator accumulator( PIN_PACC, PIN_PUMP );
 SMC smc(PIN_PMC1, PIN_PMC2, PIN_SMC);
 Brakes brakes = Brakes( PIN_PFL, PIN_PFR, PIN_SLAFL, PIN_SLAFR, PIN_SLRFL, PIN_SLRFR);
 
@@ -562,11 +562,11 @@ static void process_ps_ctrl_brake_command( const uint8_t * const rx_frame_buffer
     rx_frame_ps_ctrl_brake_command.timestamp = GET_TIMESTAMP_MS();
 
     unsigned int pedal_command = control_data->pedal_command;
-    pressure_req = map(pedal_command, 0, 65535, 48, 230); // map to voltage range 
+    pressure_req = map(pedal_command, 0, 65535, 48, 230); // map to voltage range
     pressure_req = pressure_req / 100;
     DEBUG_PRINT("pressure_req: ");
     DEBUG_PRINT(pressure_req);
-     
+
 
 }
 
@@ -629,44 +629,44 @@ void handle_ready_rx_frames(void) {
 
 
 
-void waitEnter() 
+void waitEnter()
 {
     controlEnabled = false;
 
     // open master cylinder solenoids
-    smc.solenoidsOpen(); 
-    brakes.depowerSLA(); 
-    brakes.depowerSLR(); 
+    smc.solenoidsOpen();
+    brakes.depowerSLA();
+    brakes.depowerSLR();
 
     DEBUG_PRINT( "Entered wait state" );
 }
 
-void waitUpdate() 
+void waitUpdate()
 {
     // keep accumulator pressurized
     accumulator.maintainPressure();
 
     // TODO: Is this check needed? Don't we force transition elsewhere?
-    if( pressure_req > ZERO_PRESSURE + .01 && controlEnabled ) 
+    if( pressure_req > ZERO_PRESSURE + .01 && controlEnabled )
     {
         brakeStateMachine.transitionTo(Brake);
     }
 }
 
-void waitExit() 
+void waitExit()
 {
 }
 
 void brakeEnter()
 {
     // close master cylinder solenoids because they'll spill back to the reservoir
-    smc.solenoidsClose(); 
+    smc.solenoidsClose();
 
-    digitalWrite( PIN_BREAK_SWITCH_1, LOW );
-    digitalWrite( PIN_BREAK_SWITCH_2, LOW );
+    digitalWrite( PIN_BRAKE_SWITCH_1, LOW );
+    digitalWrite( PIN_BRAKE_SWITCH_2, LOW );
 
     // close SLRRs, they are normally open for failsafe conditions
-    brakes.depowerSLR(); 
+    brakes.depowerSLR();
 
     DEBUG_PRINT("entered brake state");
 }
@@ -712,21 +712,21 @@ void brakeUpdate()
 
         // some logic to set a samplerate for data which is sent to processing for plotting
         unsigned long currentMillis = millis();
-        if ((unsigned long)(currentMillis - previousMillis) >= 100) 
+        if ((unsigned long)(currentMillis - previousMillis) >= 100)
         {
             previousMillis = currentMillis;
         }
 
 
         // if pressure is too high
-        if( pressurePID_output < -0.1 ) 
+        if( pressurePID_output < -0.1 )
         {
             brakes.depowerSLA();
             brakes.powerSLR(calculateSLRDutyCycle(pressurePID_output));
-        } 
+        }
 
         // if pressure is too low
-        if( pressurePID_output > 0.1 ) 
+        if( pressurePID_output > 0.1 )
         {
             brakes.depowerSLR();
             brakes.powerSLA(calculateSLADutyCycle(pressurePID_output));
@@ -734,7 +734,7 @@ void brakeUpdate()
 
 
         // if driver is not braking, transition to wait state
-        if( pressure_req <= ZERO_PRESSURE) 
+        if( pressure_req <= ZERO_PRESSURE)
         {
             DEBUG_PRINT("pressure request below threshold");
             brakeStateMachine.transitionTo( Wait );
@@ -744,17 +744,17 @@ void brakeUpdate()
 
 
 //
-void brakeExit() 
+void brakeExit()
 {
     // close master cylinder solenoids
-    smc.solenoidsOpen(); 
+    smc.solenoidsOpen();
 
     // depower wheel solenoids to vent brake pressure at wheels
     brakes.depowerSLA();
 
     // unswitch brake switch
-    digitalWrite( PIN_BREAK_SWITCH_1, HIGH );
-    digitalWrite( PIN_BREAK_SWITCH_2, HIGH );
+    digitalWrite( PIN_BRAKE_SWITCH_1, HIGH );
+    digitalWrite( PIN_BRAKE_SWITCH_2, HIGH );
 }
 
 
@@ -765,16 +765,16 @@ static void check_rx_timeouts( void )
     uint32_t delta = 0;
 
     // get time since last receive
-    get_update_time_delta_ms( 
-			rx_frame_ps_ctrl_brake_command.timestamp, 
-			GET_TIMESTAMP_MS(), 
+    get_update_time_delta_ms(
+			rx_frame_ps_ctrl_brake_command.timestamp,
+			GET_TIMESTAMP_MS(),
 			&delta );
 
     // check rx timeout
-    if( delta >= PS_CTRL_RX_WARN_TIMEOUT ) 
+    if( delta >= PS_CTRL_RX_WARN_TIMEOUT )
     {
         // disable control from the PolySync interface
-        if( controlEnabled ) 
+        if( controlEnabled )
         {
             Serial.println("control disabled: timeout");
             controlEnabled = false;
@@ -785,7 +785,7 @@ static void check_rx_timeouts( void )
 
 
 // the setup routine runs once when you press reset:
-void setup( void ) 
+void setup( void )
 {
 
     // duty Scalers good for 0x05
@@ -821,16 +821,16 @@ void setup( void )
     memset( &rx_frame_ps_ctrl_brake_command, 0, sizeof(rx_frame_ps_ctrl_brake_command) );
 
     // relay boards are active low, set to high before setting output to avoid unintended energisation of relay
-    digitalWrite( PIN_BREAK_SWITCH_1, HIGH );
-    digitalWrite( PIN_BREAK_SWITCH_2, HIGH );
-    pinMode( PIN_BREAK_SWITCH_1, OUTPUT );
-    pinMode( PIN_BREAK_SWITCH_2, OUTPUT );
+    digitalWrite( PIN_BRAKE_SWITCH_1, HIGH );
+    digitalWrite( PIN_BRAKE_SWITCH_2, HIGH );
+    pinMode( PIN_BRAKE_SWITCH_1, OUTPUT );
+    pinMode( PIN_BRAKE_SWITCH_2, OUTPUT );
 
     // depower all the things
     accumulator.pumpOff();
     smc.solenoidsOpen();
 
-    // close rear slrs. These should open only for emergencies and to release break pressure
+    // close rear slrs. These should open only for emergencies and to release brake pressure
     brakes.depowerSLR();
     brakes.depowerSLA();
 
@@ -854,7 +854,7 @@ void setup( void )
 
 }
 
-void loop() 
+void loop()
 {
 
     // update the global system update timestamp, ms
@@ -865,9 +865,9 @@ void loop()
     publish_timed_tx_frames();
 
     check_rx_timeouts();
-        
+
     // check pressures on master cylinder (pressure from pedal)
-    smc.checkPedal();      
+    smc.checkPedal();
 
     brakeStateMachine.update();
-} 
+}

--- a/firmware/tests/brake_bench/brake_controller_r0_test.ino
+++ b/firmware/tests/brake_bench/brake_controller_r0_test.ino
@@ -21,11 +21,11 @@ int val = 0;
 
 
 // accumulator pump motor
-const byte PIN_PUMP = 9;     
+const byte PIN_PUMP = 9;
 
 
 // brake spoofer relay pin definitions
-const byte PIN_BREAK_SWITCH = 48;
+const byte PIN_BRAKE_SWITCH = 48;
 
 
 // sensor pin (analog) definitions
@@ -51,22 +51,22 @@ int SLADutyMax,
     SLRDutyMin;
 
 
-static void init_serial( void ) 
+static void init_serial( void )
 {
     Serial.begin( SERIAL_BAUD );
 }
 
 
 
-static void init_can ( void ) 
+static void init_can ( void )
 {
     // wait until we have initialized
     while( CAN.begin(CAN_BAUD) != CAN_OK )
-    {   
+    {
         // wait a little
         delay( CAN_INIT_RETRY_DELAY );
         Serial.println( "init_can: retrying" );
-    }   
+    }
 
     // debug log
     Serial.println( "init_can: pass" );
@@ -101,7 +101,7 @@ void test_power_drivers() {
         // wait for 30 milliseconds to see the dimming effect
         delay(100);
         val = analogRead(A3);    // read the input pin
-        Serial.println(val);  
+        Serial.println(val);
     }
 
     // fade from 100% duty cycle back to 0% duty cycle
@@ -127,12 +127,12 @@ void test_power_drivers() {
 void test_pump_relay() {
 
     // flush all previous received and transmitted data
-    Serial.flush(); 
+    Serial.flush();
 
     while(!Serial.available()) {
-        digitalWrite(PIN_PUMP, HIGH);   
-        delay(1000);                   
-        digitalWrite(PIN_PUMP, LOW);  
+        digitalWrite(PIN_PUMP, HIGH);
+        delay(1000);
+        digitalWrite(PIN_PUMP, LOW);
         delay(1000);
     }
 }
@@ -143,12 +143,12 @@ void test_pump_relay() {
 void test_switch_relay() {
 
     // flush all previous received and transmitted data
-    Serial.flush(); 
+    Serial.flush();
 
     while(!Serial.available()) {
-        digitalWrite(PIN_BREAK_SWITCH, HIGH);   
-        delay(1000);                       
-        digitalWrite(PIN_BREAK_SWITCH, LOW);   
+        digitalWrite(PIN_BRAKE_SWITCH, HIGH);
+        delay(1000);
+        digitalWrite(PIN_BRAKE_SWITCH, LOW);
         delay(1000);
     }
 }
@@ -163,7 +163,7 @@ void test_CAN_send() {
     //Create data packet for CAN message
     unsigned char canMsg[8] = {cantxValue, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
     // send data:  id = 0x123, standrad frame, data len = 8, stmp: data buf
-    CAN.sendMsgBuf(0x07B, 0, 8, canMsg); 
+    CAN.sendMsgBuf(0x07B, 0, 8, canMsg);
     delay(250);
 }
 

--- a/firmware/tests/brake_controller/brake_controller_r0_test.ino
+++ b/firmware/tests/brake_controller/brake_controller_r0_test.ino
@@ -93,7 +93,7 @@ static void get_update_time_delta_ms(
         }
 }
 
-// MOSFET pin (digital) definitions ( MOSFETs control the solenoids ) 
+// MOSFET pin (digital) definitions ( MOSFETs control the solenoids )
 // pins are not perfectly sequential because the clock frequency of certain pins is different.
 const byte PIN_SLAFL = 4;      // front left actuation
 const byte PIN_SLAFR = 2;      // front right actuation
@@ -104,14 +104,14 @@ const byte PIN_PUMP = 49;     // accumulator pump motor
 
 
 // brake spoofer relay pin definitions
-const byte PIN_BREAK_SWITCH_1 = 48;
+const byte PIN_BRAKE_SWITCH_1 = 48;
 
 
 // sensor pin (analog) definitions
 const byte PIN_PACC = 9;       // pressure accumulator sensor
 const byte PIN_PMC1 = 10;      // pressure master cylinder sensor 1
 const byte PIN_PMC2 = 11;      // pressure master cylinder sensor 2
-const byte PIN_PRL = 12;       // pressure rear left sensor 
+const byte PIN_PRL = 12;       // pressure rear left sensor
 const byte PIN_PFR = 13;       // pressure front right sensor
 const byte PIN_PFL = 14;       // pressure front left sensor
 const byte PIN_PRR = 15;       // pressure rear right sensor
@@ -119,11 +119,11 @@ const byte PIN_PRR = 15;       // pressure rear right sensor
 
 // the following are guesses, these need to be debugged/researched
 const double ZERO_PRESSURE = 0.48;        // The voltage the sensors read when no pressure is present
-const double MIN_PACC = 2.3;              // minumum accumulator pressure to maintain 
+const double MIN_PACC = 2.3;              // minumum accumulator pressure to maintain
 const double MAX_PACC = 2.4;              // max accumulator pressure to maintain
 const double PEDAL_THRESH = 0.5;          // Pressure for pedal interference
 
-int SLADutyMax, 
+int SLADutyMax,
     SLADutyMin,
     SLRDutyMax,
     SLRDutyMin;
@@ -136,8 +136,8 @@ double pressure_req,
 
 uint8_t incomingSerialByte;
 
-int deltaT=10, 
-    currMicros, 
+int deltaT=10,
+    currMicros,
     lastMicros = 0;
 
 unsigned long previousMillis=0;
@@ -155,11 +155,11 @@ int local_override = 0;
 
 // initialize states
 State Wait = State(waitEnter, waitUpdate, waitExit);        // Wait for brake instructions
-State Brake = State(brakeEnter, brakeUpdate, brakeExit);    // Control braking 
+State Brake = State(brakeEnter, brakeUpdate, brakeExit);    // Control braking
 
 
 // initialize state machine, start in state: Wait
-FSM brakeStateMachine = FSM(Wait);     
+FSM brakeStateMachine = FSM(Wait);
 
 
 int calculateSLADutyCycle(float pre) {
@@ -201,36 +201,36 @@ struct Accumulator {
     byte _controlPin = 99;
     Accumulator( byte sensorP, byte relayP );
 
-    void updatePressure() 
+    void updatePressure()
     {
     }
-    
 
-    // turn relay on or off 
-    void pumpOn() 
+
+    // turn relay on or off
+    void pumpOn()
     {
       digitalWrite(_controlPin, HIGH);
     }
 
-    
-    void pumpOff() 
+
+    void pumpOff()
     {
       digitalWrite(_controlPin, LOW);
     }
 
     // maintain accumulator pressure
-    void maintainPressure() 
+    void maintainPressure()
     {
       _pressure = convertToVoltage(analogRead(_sensorPin));
       //Serial.println(_pressure);
 
 
-      if( _pressure < MIN_PACC ) 
+      if( _pressure < MIN_PACC )
       {
           pumpOn();
       }
 
-      if( _pressure > MAX_PACC ) 
+      if( _pressure > MAX_PACC )
       {
           pumpOff();
       }
@@ -241,7 +241,7 @@ struct Accumulator {
 
 
 // accumulator constructor
-Accumulator::Accumulator( byte sensorPin, byte controlPin ) 
+Accumulator::Accumulator( byte sensorPin, byte controlPin )
 {
   _sensorPin = sensorPin;
   _controlPin = controlPin;
@@ -274,11 +274,11 @@ struct SMC {
         _pressure2 = convertToVoltage(analogRead(_sensor2Pin));
 
         // if current pedal pressure is greater than limit, disable
-        if (_pressure1 > PEDAL_THRESH || _pressure2 > PEDAL_THRESH ) 
+        if (_pressure1 > PEDAL_THRESH || _pressure2 > PEDAL_THRESH )
         {
             DEBUG_PRINT("Brake Pedal Detected");
             DEBUG_PRINT(_pressure1);
-            pressure_req = .48; 
+            pressure_req = .48;
             local_override = 1;
             brakeStateMachine.transitionTo(Wait);
         }
@@ -288,12 +288,12 @@ struct SMC {
         }
     }
 
-    void solenoidsClose() 
+    void solenoidsClose()
     {
         analogWrite( _controlPin, 255 );
     }
 
-    void solenoidsOpen() 
+    void solenoidsOpen()
     {
         analogWrite( _controlPin, 0 );
     }
@@ -302,7 +302,7 @@ struct SMC {
 
 
 
-SMC::SMC( byte sensor1Pin, byte sensor2Pin, byte controlPin ) 
+SMC::SMC( byte sensor1Pin, byte sensor2Pin, byte controlPin )
 {
   _sensor1Pin = sensor1Pin;
   _sensor2Pin = sensor2Pin;
@@ -327,14 +327,14 @@ struct Brakes {
     byte _solenoidPinLeftR = 99;          // pin associated with MOSFET, associated with actuation solenoid
     byte _solenoidPinRightR = 99;         // pin associated with MOSFET, associated with return solenoid
     bool _increasingPressure = false;     // used to track if pressure should be increasing
-    bool _decreasingPressure = false;     // used to track if pressure should be decreasing 
-    unsigned long _previousMillis = 0;    // will store last time solenoid was updated 
+    bool _decreasingPressure = false;     // used to track if pressure should be decreasing
+    unsigned long _previousMillis = 0;    // will store last time solenoid was updated
 
 
     Brakes( byte sensorPinLeft, byte sensorPinRight, byte solenoidPinLeftA, byte solenoidPinRightA, byte solenoidPinLeftR, byte solenoidPinRightR );
 
 
-    void depowerSolenoids() 
+    void depowerSolenoids()
     {
       analogWrite(_solenoidPinLeftA, 0);
       analogWrite(_solenoidPinRightA, 0);
@@ -345,14 +345,14 @@ struct Brakes {
 
 
     // fill pressure
-    void powerSLA(int scaler) 
+    void powerSLA(int scaler)
     {
         analogWrite( _solenoidPinLeftA, scaler );
         analogWrite( _solenoidPinRightA, scaler );
     }
 
-    
-    void depowerSLA() 
+
+    void depowerSLA()
     {
         analogWrite( _solenoidPinLeftA, 0 );
         analogWrite( _solenoidPinRightA, 0 );
@@ -360,7 +360,7 @@ struct Brakes {
 
 
     // spill pressure
-    void powerSLR(int scaler) 
+    void powerSLR(int scaler)
     {
         Serial.println(scaler);
         analogWrite( _solenoidPinLeftR, scaler );
@@ -368,16 +368,16 @@ struct Brakes {
         analogWrite( 5, scaler );
     }
 
-    
-    void depowerSLR() 
+
+    void depowerSLR()
     {
         digitalWrite( _solenoidPinLeftR, LOW );
         digitalWrite( _solenoidPinRightR, LOW );
     }
 
 
-    // take a pressure reading 
-    void updatePressure() 
+    // take a pressure reading
+    void updatePressure()
     {
       _pressureLeft = convertToVoltage( analogRead(_sensorPinLeft) );
       _pressureRight = convertToVoltage( analogRead(_sensorPinRight) );
@@ -410,8 +410,8 @@ Brakes::Brakes( byte sensorPLeft, byte sensorPRight, byte solenoidPinLeftA, byte
 
 
 
-// Instantiate objects 
-Accumulator accumulator( PIN_PACC, PIN_PUMP ); 
+// Instantiate objects
+Accumulator accumulator( PIN_PACC, PIN_PUMP );
 SMC smc(PIN_PMC1, PIN_PMC2, PIN_SMC);
 Brakes brakes = Brakes( PIN_PFL, PIN_PFL, PIN_SLAFL, PIN_SLAFR, PIN_SLRFL, PIN_SLRFR);
 
@@ -450,41 +450,41 @@ static void init_can( void )
 
 // A function to parse incoming serial bytes
 void processSerialByte() {
-  
+
     if (incomingSerialByte == 'a') {                  // increase pressure
-        pressure_req += 0.2; 
+        pressure_req += 0.2;
     }
     if (incomingSerialByte == 'd') {                  // decrease pressure
-        pressure_req -= 0.2; 
+        pressure_req -= 0.2;
     }
 
     if (incomingSerialByte == 'p') {                  // reset
-        pressure_req = .48; 
-        DEBUG_PRINT("reset pressure request");    
+        pressure_req = .48;
+        DEBUG_PRINT("reset pressure request");
     }
     if (incomingSerialByte == 'q') {                  // reset
-        smc.solenoidsOpen(); 
-        DEBUG_PRINT("opened SMCs");    
+        smc.solenoidsOpen();
+        DEBUG_PRINT("opened SMCs");
     }
     if (incomingSerialByte == 'e') {                  // reset
-        smc.solenoidsClose(); 
-        DEBUG_PRINT("closed SMCs");    
+        smc.solenoidsClose();
+        DEBUG_PRINT("closed SMCs");
     }
     if (incomingSerialByte == 'z') {                  // reset
-        brakes.depowerSLR(); 
-        DEBUG_PRINT("depower SLRs");    
+        brakes.depowerSLR();
+        DEBUG_PRINT("depower SLRs");
     }
     if (incomingSerialByte == 'c') {                  // reset
-        brakes.powerSLR(255); 
-        DEBUG_PRINT("power SLRs");    
+        brakes.powerSLR(255);
+        DEBUG_PRINT("power SLRs");
     }
     if (incomingSerialByte == 'n') {                  // reset
-        brakes.powerSLA(255); 
-        DEBUG_PRINT("power SLAs");    
+        brakes.powerSLA(255);
+        DEBUG_PRINT("power SLAs");
     }
     if (incomingSerialByte == 'm') {                  // reset
-        brakes.depowerSLA(); 
-        DEBUG_PRINT("depower SLAs");    
+        brakes.depowerSLA();
+        DEBUG_PRINT("depower SLAs");
     }
     if (incomingSerialByte == 'u') {                  // reset
         Serial.println(accumulator._pressure);
@@ -575,11 +575,11 @@ static void process_ps_ctrl_brake_command( const uint8_t * const rx_frame_buffer
     }
 
     unsigned int pedal_command = control_data->pedal_command;
-    pressure_req = map(pedal_command, 0, 65535, 48, 230); // map to voltage range 
+    pressure_req = map(pedal_command, 0, 65535, 48, 230); // map to voltage range
     pressure_req = pressure_req / 100;
     DEBUG_PRINT("pressure_req: ");
     DEBUG_PRINT(pressure_req);
-     
+
 
 }
 
@@ -642,48 +642,48 @@ void handle_ready_rx_frames(void) {
 
 
 
-void waitEnter() 
+void waitEnter()
 {
     controlEnabled = false;
 
     // open master cylinder solenoids
-    smc.solenoidsOpen(); 
-    brakes.depowerSLA(); 
-    brakes.depowerSLR(); 
+    smc.solenoidsOpen();
+    brakes.depowerSLA();
+    brakes.depowerSLR();
 
     DEBUG_PRINT( "Entered wait state" );
 }
 
-void waitUpdate() 
+void waitUpdate()
 {
     // keep accumulator pressurized
     accumulator.maintainPressure();
 
     // TODO: Is this check needed? Don't we force transition elsewhere?
-    if( pressure_req > ZERO_PRESSURE + .01 ) 
+    if( pressure_req > ZERO_PRESSURE + .01 )
     {
         brakeStateMachine.transitionTo(Brake);
     }
 }
 
-void waitExit() 
+void waitExit()
 {
 }
 
 void brakeEnter()
 {
     // close master cylinder solenoids because they'll spill back to the reservoir
-    smc.solenoidsClose(); 
+    smc.solenoidsClose();
 
-    digitalWrite( PIN_BREAK_SWITCH_1, LOW );
+    digitalWrite( PIN_BRAKE_SWITCH_1, LOW );
 
     // close SLRRs, they are normally open for failsafe conditions
-    brakes.depowerSLR(); 
+    brakes.depowerSLR();
 
     DEBUG_PRINT("entered brake state");
 }
 
-void brakeUpdate() 
+void brakeUpdate()
 {
     // maintain accumulator pressure
     accumulator.maintainPressure();
@@ -729,21 +729,21 @@ void brakeUpdate()
 
         // some logic to set a samplerate for data which is sent to processing for plotting
         unsigned long currentMillis = millis();
-        if ((unsigned long)(currentMillis - previousMillis) >= 100) 
+        if ((unsigned long)(currentMillis - previousMillis) >= 100)
         {
             previousMillis = currentMillis;
         }
 
 
         // if pressure is too high
-        if( pressurePID_output < -0.1 ) 
+        if( pressurePID_output < -0.1 )
         {
             brakes.depowerSLA();
             brakes.powerSLR(calculateSLRDutyCycle(pressurePID_output));
-        } 
+        }
 
         // if pressure is too low
-        if( pressurePID_output > 0.1 ) 
+        if( pressurePID_output > 0.1 )
         {
             brakes.depowerSLR();
             brakes.powerSLA(calculateSLADutyCycle(pressurePID_output));
@@ -751,7 +751,7 @@ void brakeUpdate()
 
 
         // if driver is not braking, transition to wait state
-        if( pressure_req <= ZERO_PRESSURE) 
+        if( pressure_req <= ZERO_PRESSURE)
         {
             DEBUG_PRINT("pressure request below threshold");
             brakeStateMachine.transitionTo( Wait );
@@ -759,22 +759,22 @@ void brakeUpdate()
     }
 }
 
-void brakeExit() 
+void brakeExit()
 {
     // close master cylinder solenoids
-    smc.solenoidsOpen(); 
+    smc.solenoidsOpen();
 
     // depower wheel solenoids to vent brake pressure at wheels
     brakes.depowerSLA();
 
     // unswitch brake switch
-    digitalWrite( PIN_BREAK_SWITCH_1, HIGH );
+    digitalWrite( PIN_BRAKE_SWITCH_1, HIGH );
 }
 
 
 
 // the setup routine runs once when you press reset:
-void setup( void ) 
+void setup( void )
 {
 
     // duty Scalers good for 0x05
@@ -790,7 +790,7 @@ void setup( void )
     //SLRDutyMax = 225;
     //SLRDutyMin = 100;
 
-    // test duty Scalers 
+    // test duty Scalers
     SLADutyMax = 100;
     SLADutyMin = 0;
     SLRDutyMax = 100;
@@ -816,14 +816,14 @@ void setup( void )
     memset( &rx_frame_ps_ctrl_brake_command, 0, sizeof(rx_frame_ps_ctrl_brake_command) );
 
     // relay boards are active low, set to high before setting output to avoid unintended energisation of relay
-    digitalWrite( PIN_BREAK_SWITCH_1, HIGH );
-    pinMode( PIN_BREAK_SWITCH_1, OUTPUT );
+    digitalWrite( PIN_BRAKE_SWITCH_1, HIGH );
+    pinMode( PIN_BRAKE_SWITCH_1, OUTPUT );
 
     // depower all the things
     accumulator.pumpOff();
     smc.solenoidsOpen();
 
-    // close rear slrs. These should open only for emergencies and to release break pressure
+    // close rear slrs. These should open only for emergencies and to release brake pressure
     brakes.depowerSLR();
     brakes.depowerSLA();
 
@@ -847,7 +847,7 @@ void setup( void )
 
 }
 
-void loop() 
+void loop()
 {
 
     // update the global system update timestamp, ms
@@ -856,16 +856,16 @@ void loop()
     //handle_ready_rx_frames();
 
     //publish_timed_tx_frames();
-        
+
     // check pressures on master cylinder (pressure from pedal)
     //smc.checkPedal();
 
     // read and parse incoming serial commands
-    if( Serial.available() > 0 ) 
+    if( Serial.available() > 0 )
     {
         incomingSerialByte = Serial.read();
         processSerialByte();
     }
-      
+
     brakeStateMachine.update();
-} 
+}


### PR DESCRIPTION
Prior to this pull request, the word "break" was incorrectly used instead of "brake".  After this commit, this is corrected.  Care was taken to not replace any break commands in code.