### PR TITLE
Add smoother control of steering, brake

### DIFF
--- a/control/joystick_commander/include/commander.h
+++ b/control/joystick_commander/include/commander.h
@@ -120,7 +120,7 @@
  * @brief Steering command steering wheel velocity minimum valid value. [uint8_t]
  *
  */
-#define STEERING_COMMAND_MAX_VELOCITY_MIN (0)
+#define STEERING_COMMAND_MAX_VELOCITY_MIN (20)
 
 
 /**
@@ -135,6 +135,27 @@
  *
  */
 #define STEERING_COMMAND_MAX_VELOCITY_FACTOR (2)
+
+
+/**
+ * @brief Exponential filter factor for braking commands.
+ *
+ */
+#define BRAKES_FILTER_FACTOR (0.2)
+
+
+/**
+ * @brief Exponential filter factor for throttle commands.
+ *
+ */
+#define THROTTLE_FILTER_FACTOR (0.2)
+
+
+/**
+ * @brief Exponential filter factor for steering commands.
+ *
+ */
+#define STEERING_FILTER_FACTOR (0.1)
 
 
 

--- a/control/joystick_commander/include/joystick.h
+++ b/control/joystick_commander/include/joystick.h
@@ -101,18 +101,53 @@ typedef struct
 } joystick_guid_s;
 
 
+typedef struct
+{
+    //
+    //
+    double brake_setpoint_average;
+    //
+    //
+    double throttle_setpoint_average;
+    //
+    //
+    double steering_setpoint_average;
+    //
+    //
+    double last_joystick_state_steering;
+} joystick_state_s;
+
+
 /**
  * @brief Joystick device.
  *
  */
 typedef struct
 {
+    //
+    //
     void *handle;
+    //
+    //
     joystick_guid_s guid;
+    //
+    //
+    joystick_state_s joystick_state;
 
 } joystick_device_s;
 
 
+
+
+/**
+ * @brief Initialize joystick state struct.
+ *
+ * @return ERROR code
+ * \li \ref NOERR (1) if success.
+ * \li \ref ERROR (0) if failure.
+ *
+ */
+int jstick_init_state( joystick_device_s * const jstick );
 
 
 /**
@@ -263,6 +298,21 @@ double jstick_normalize_trigger_position(
         const int position,
         const double range_min,
         const double range_max );
+
+
+/**
+ * @brief Calculate exponential average from current and previous values.
+ *
+ * @param [in] average Pointer to exponential average from previous calculations.
+ * @param [in] setpoint New input value to exponential average.
+ * @param [in] factor Factor applied to exponential averaging.
+ *
+ * @return New exponential average.
+ *
+ */
+double jstick_calc_exponential_average( double * const average,
+                                        const double setpoint,
+                                        const double factor );
 
 
 

--- a/control/joystick_commander/src/joystick.c
+++ b/control/joystick_commander/src/joystick.c
@@ -90,6 +90,42 @@
 
 
 // *****************************************************
+// Function:    jstick_init_state
+// 
+// Purpose:     Initialize the joystick state struct
+// 
+// Returns:     int - ERROR or NOERROR
+// 
+// Parameters:  jstick - pointer to the joystick to open
+// 
+// *****************************************************
+int jstick_init_state( joystick_device_s * const jstick )
+{
+    int return_code = NOERR;
+    
+    if( jstick == NULL )
+    {
+        return_code = ERROR;
+    }
+    
+    if( return_code == NOERR )
+    {
+        jstick->joystick_state.brake_setpoint_average = 0;
+
+        jstick->joystick_state.throttle_setpoint_average = 0;
+
+        jstick->joystick_state.steering_setpoint_average = 0;
+
+        jstick->joystick_state.last_joystick_state_steering = 0;
+    }
+    
+    return ( return_code );
+}
+
+
+
+
+// *****************************************************
 // Function:    jstick_init_subsystem
 // 
 // Purpose:     Initialize the joystick subsystem
@@ -456,4 +492,26 @@ double jstick_normalize_trigger_position( const int position,
     const double b2 = range_max;
     
     return jstick_calc_log_range( a1, a2, b1, b2, s );
+}
+
+
+// *****************************************************
+// Function:    jstick_calc_exponential_average 
+// 
+// Purpose:     Calculate an exponential average based on previous values.
+// 
+// Returns:     double - the exponentially averaged result.
+// 
+// Parameters:  average - pointer to previous result of exponential averaging
+//              setpoint - new setpoint to incorperate into average
+//              factor - factor of exponential average
+// 
+// *****************************************************
+double jstick_calc_exponential_average( double * const average,
+                                        const double setpoint,
+                                        const double factor )
+{
+    (*average) = setpoint * factor + ( 1 - factor ) * (*average);
+    
+    return (*average);
 }

--- a/control/joystick_commander/src/node.c
+++ b/control/joystick_commander/src/node.c
@@ -252,7 +252,12 @@ static int init_joystick( commander_s * commander )
     ret = jstick_init_subsystem();
     
     if( ret == ERROR )
-        printf("init subsystem error\n");    
+        printf("init subsystem error\n");
+
+    ret = jstick_init_state( &commander->joystick );
+    
+    if( ret == ERROR )
+        printf("joystick joystick_device_s is NULL error\n");
 
     // get number of joysticks visible
     const int num_joysticks = jstick_get_num_devices();

--- a/control/joystick_commander/src/node.c
+++ b/control/joystick_commander/src/node.c
@@ -252,12 +252,16 @@ static int init_joystick( commander_s * commander )
     ret = jstick_init_subsystem();
     
     if( ret == ERROR )
+    {
         printf("init subsystem error\n");
+    }
 
     ret = jstick_init_state( &commander->joystick );
     
     if( ret == ERROR )
+    {
         printf("joystick joystick_device_s is NULL error\n");
+    }
 
     // get number of joysticks visible
     const int num_joysticks = jstick_get_num_devices();


### PR DESCRIPTION
Prior to this commit steering, throttle and brake control didn't have any filtering of their respective setpoints. Further, steering lacked the functionality to smooth control via dynamically changing the max steering rate. This commit adds the functionality to smooth steering and brake through exponential filtering. It also adds the functionality to smooth throttle control through filtering, but does not implement this (as it was not neccessary). Finally it adds dynamic control of the max steering wheel rate, which further smooths out control.