### PR TITLE
Add correct factor for steering max velocity

### DIFF
--- a/control/joystick_commander/include/commander.h
+++ b/control/joystick_commander/include/commander.h
@@ -134,7 +134,7 @@
  * @brief Steering command steering wheel velocity scale factor.
  *
  */
-#define STEERING_COMMAND_MAX_VELOCITY_FACTOR (2)
+#define STEERING_COMMAND_MAX_VELOCITY_FACTOR (0.25)
 
 
 /**


### PR DESCRIPTION
Prior to this commit the multiplication factor for the steering wheel max velocity field was too low. This commit adds the correct multiplication factor.