### PR TITLE
Add improved PID control

### DIFF
--- a/firmware/arduino_libraries/PID/PID.h
+++ b/firmware/arduino_libraries/PID/PID.h
@@ -71,7 +71,7 @@ typedef struct
     double proportional_gain;
     double integral_gain;
     double derivative_gain;
-    double prev_error;
+    double prev_input;
     double int_error;
     double control;
     double prev_steering_angle;
@@ -80,10 +80,10 @@ typedef struct
 
 
 
-int pid_update( PID* pid, double curr_error, double dt );
+int pid_update( PID* pid, double setpoint, double input, double dt );
 
 
-void pid_zeroize( PID* pid );
+void pid_zeroize( PID* pid, double integral_windup_guard );
 
 
 

--- a/firmware/brake/kia_soul_ps/brake_control_module.ino
+++ b/firmware/brake/kia_soul_ps/brake_control_module.ino
@@ -56,7 +56,10 @@
 #define CAN_CS 53
 
 // ms
-#define PS_CTRL_RX_WARN_TIMEOUT (150)
+#define PS_CTRL_RX_WARN_TIMEOUT ( 150 )
+
+// Braking PID windup guard
+#define BRAKE_PID_WINDUP_GUARD ( 500 )
 
 
 
@@ -658,7 +661,7 @@ void brakeUpdate()
         pidParams.proportional_gain = 10.0;
         pidParams.integral_gain = 1.5;
 
-        int ret = pid_update( &pidParams, pressureRate_target - pressureRate, 0.050 );
+        int ret = pid_update( &pidParams, pressureRate_target, pressureRate, 0.050 );
 
         if( ret == PID_SUCCESS )
         {
@@ -790,7 +793,7 @@ void setup( void )
     last_update_ms = GET_TIMESTAMP_MS();
 
     // Initialize PID params
-    pid_zeroize( &pidParams );
+    pid_zeroize( &pidParams, BRAKE_PID_WINDUP_GUARD );
 
     // debug log
     DEBUG_PRINT( "init: pass" );

--- a/firmware/steering/kia_soul_ps/current_control_state.h
+++ b/firmware/steering/kia_soul_ps/current_control_state.h
@@ -38,15 +38,15 @@ typedef struct
     //
     //
     bool control_enabled; /* Is control currently enabled flag */
-	//
-	//
-	bool emergency_stop; /* Emergency stop has been acitivated by higher level controller */
-	//
-	//
-	double current_steering_angle; /* Current steering angle as reported by car */
-	//
-	//
-	double commanded_steering_angle; /* Commanded steering angle as specified by higher level controller */
+    //
+    //
+    bool emergency_stop; /* Emergency stop has been acitivated by higher level controller */
+    //
+    //
+    double current_steering_angle; /* Current steering angle as reported by car */
+    //
+    //
+    double commanded_steering_angle; /* Commanded steering angle as specified by higher level controller */
     //
     //
     double PID_input; /* Input to PID controller */
@@ -58,18 +58,18 @@ typedef struct
     double PID_setpoint; /* Setpoint for PID controller */
     //
     //
-    double SA_Kp = 0.32; /* Proportional gain for PID controller */
+    double SA_Kp = 0.3; /* Proportional gain for PID controller */
     //
     //
-    double SA_Ki = 2.0; /* Integral gain for PID controller */
+    double SA_Ki = 1.3; /* Integral gain for PID controller */
     //
-    //    
+    //
     double SA_Kd = 0.03; /* Derivative gain for PID controller */
     //
     //
     double steering_angle_rate_max = 1000.0; /* Maximum rate of change of steering wheel angle */
     //
-    //    
+    //
     double steering_angle_last; /* Last steering angle recorded */
     //
     //

--- a/firmware/tests/brake_controller/brake_controller_r0_test.ino
+++ b/firmware/tests/brake_controller/brake_controller_r0_test.ino
@@ -37,6 +37,9 @@
 // chip select pin for CAN Shield
 #define CAN_CS 53
 
+// Braking PID windup guard
+#define BRAKE_PID_WINDUP_GUARD ( 500 )
+
 
 
 
@@ -706,7 +709,7 @@ void brakeUpdate()
     pidParams.derivative_gain = 0.50;
     pidParams.proportional_gain = 10.0;
     pidParams.integral_gain = 1.5;
-    int ret = pid_update( &pidParams, pressureRate_target - pressureRate, 0.050 );
+    int ret = pid_update( &pidParams, pressureRate_target, pressureRate, 0.050 );
 
     if( ret == PID_SUCCESS )
     {
@@ -838,7 +841,7 @@ void setup( void )
     //last_update_ms = GET_TIMESTAMP_MS();
 
     // Initialize PID params
-    pid_zeroize( &pidParams );
+    pid_zeroize( &pidParams,  BRAKE_PID_WINDUP_GUARD );
 
     // debug log
     DEBUG_PRINT( "init: pass" );


### PR DESCRIPTION
Prior to this commit the PID library lacked the functionality to deal with derivative kick, as well as the functionality to properly set integral windup guard. This commit adds this new functionality. In addition it updates any modules that use the PID library to reflect these changes. Finally it adds new PID parameters for steering, that have been re-tuned after making these changes to the PID library.