### PR TITLE
Fix the brake bench tests incorrect pin number

### DIFF
--- a/firmware/tests/brake_bench/brake_controller_r0_test.ino
+++ b/firmware/tests/brake_bench/brake_controller_r0_test.ino
@@ -21,7 +21,7 @@ int val = 0;
 
 
 // accumulator pump motor
-const byte PIN_PUMP = 9;
+const byte PIN_PUMP = 49;
 
 
 // brake spoofer relay pin definitions


### PR DESCRIPTION
Prior to this commit, the brake bench test was referencing the prototype hardware (V0.9) pin number for the accumulator pump motor.

This commit sets the correct accumulator pump pin number according to the V1.0.0 hardware
schematics defined here:

https://github.com/PolySync/OSCC/blob/devel/boards/actuator_control_board/actuator_control_board_sch_1.0.0.pdf