### PR TITLE
Fix the steering output pins

### DIFF
--- a/firmware/steering/kia_soul_ps/steering_control_module.ino
+++ b/firmware/steering/kia_soul_ps/steering_control_module.ino
@@ -676,8 +676,8 @@ void loop( )
 
             calculate_torque_spoof( control, &torque_spoof );
 
-            dac.outputA( torque_spoof.high );
-            dac.outputB( torque_spoof.low );
+            dac.outputA( torque_spoof.low );
+            dac.outputB( torque_spoof.high );
         }
         else
         {


### PR DESCRIPTION
Prior to this commit the output pins in the steering controller module were swapped for the new boards. This commit corrects these pins.