### PR TITLE
Add verbose description for max steering velocity

### DIFF
--- a/control/joystick_commander/include/commander.h
+++ b/control/joystick_commander/include/commander.h
@@ -132,6 +132,10 @@
 
 /**
  * @brief Steering command steering wheel velocity scale factor.
+ * 
+ * This factor can be increased to provide smoother, but slightly less responsive, steering control.
+ * It is recommended to smooth at the higher level, with this factor, before trying to smooth at the
+ * lower level.
  *
  */
 #define STEERING_COMMAND_MAX_VELOCITY_FACTOR (0.25)


### PR DESCRIPTION
Prior to this commit, the STEERING_COMMAND_MAX_VELOCITY_FACTOR did not include a verbose description string. Changing this factor is the recommended way to actuate smoother steering control at the lower level. Thus this description string needed to be updated to make this more clear for users. This commit adds a more verbose description for this factor.