### PR TITLE
Update the README to reflect V1.0.0 hardware status

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,10 @@ Repository Contents
 Boards
 -----
 
-Once we finish testing and validating the board designs, we will be releasing the schematics and design files along with the board test plans and testing firmware. Check back soon for complete designs.
-Once we have validated the boards, we will be shipping the boards as a kit.
+The sensor interface and actuator control board schematics and design files are located in the `OSCC/boards/` directory. If you don't have the time or fabrication resources, the boards can be purchased as a kit from the [OSCC website](http://oscc.io). 
+
 Thanks to [Trey German](https://www.PolymorphicLabs.com) and [Macrofab](https://macrofab.com/) for help desiging the boards and getting them made.
 
-
-Click [Here](http://oscc.io) to order your autonomy kit now.
 
 Building and Installing Arduino Firmware
 ------------

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Controlling Your Vehicle
 Now that all your Arduino modules are properly setup, it is time to start sending control commands. There is an example application to do this that uses the Logitech F310 Gamepad. The example interfaces to the joystick gamepad via the SDL2 joystick library and sends CAN commands over the control CAN bus via the Kvaser CANlib SDK. These CAN control commands are interpreted by the respective Arduino modules and used to actuate the vehicle.
 
 **Pre-requisites:** A Logitech F310 gamepad is required, and the SDL2 library and CANlib SDK need to be pre-installed. 
-A CAN interface adapter, such as the [Kvaser Leaflight](https://www.kvaser.com), is also required.
+A CAN interface adapter, such as the [Kvaser Leaf Light](https://www.kvaser.com), is also required.
 
 [logitech-F310](http://a.co/3GoUlkN)
 
@@ -144,14 +144,14 @@ Then navigate to the examples directory of the CANlib install.
 
 `cd /usr/src/linuxcan/canlib/examples/`
 
-You can use the "listChannels" and "canmonitor" examples to determine which CAN channel your control bus is connected to. CAN monitor will dump any data on a selected channel and list channels will tell you what channels are avaliable. You can use both to determine which channel you will need to use. Once you know the correct chanel number, you can run the joystick example with the command below.
+You can use the "listChannels" and "canmonitor" examples to determine which CAN channel your control bus is connected to. CAN monitor will dump any data on a selected channel and list channels will tell you what channels are available. You can use both to determine which channel you will need to use. Once you know the correct channel number, you can run the joystick example with the command below.
 
 `./joystick-commander <channel-number>`
 
 **Controlling the Vehicle with the Joystick Gamepad**
 
 Once the joystick commander is up and running you can use it to send commands to the Arduino modules. The controls are listed when the programs start up. Be sure the switch on the back of the controller is 
-switched to the 'X' position, not 'D'. The vehicle will only response to commands if control is enabled with the start button. The back button disables control.
+switched to the 'X' position, not 'D'. The vehicle will only respond to commands if control is enabled with the start button. The back button disables control.
 
 
 Additional Vehicles & Contributing

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Boards
 
 The sensor interface and actuator control board schematics and design files are located in the `OSCC/boards/` directory. If you don't have the time or fabrication resources, the boards can be purchased as a kit from the [OSCC website](http://oscc.io). 
 
-Thanks to [Trey German](https://www.PolymorphicLabs.com) and [Macrofab](https://macrofab.com/) for help desiging the boards and getting them made.
+Thanks to [Trey German](https://www.PolymorphicLabs.com) and [Macrofab](https://macrofab.com/) for help designing the boards and getting the boards made.
 
 
 Building and Installing Arduino Firmware


### PR DESCRIPTION
Prior to this commit, the README did not have up-to-date references to the board design status. This commit updates the "Boards" section to point to the directory in OSCC repo with the board schematics and design file resources that are required to to fabricate the V1.0.0 sensor interface and actuator control boards.

