### PR TITLE
fix/steering-voltage-threshold

### DIFF
--- a/firmware/steering/kia_soul_ps/steering_control_module.ino
+++ b/firmware/steering/kia_soul_ps/steering_control_module.ino
@@ -75,7 +75,7 @@
 #define STEERING_WHEEL_CUTOFF_THRESHOLD ( 3000 )
 
 // Threshhold to detect when there is a discrepancy between DAC and ADC values
-#define VOLTAGE_THRESHOLD               ( 200 )     // mV
+#define VOLTAGE_THRESHOLD               ( 0.096 )     // mV
 
 #define SAMPLE_A                        ( 0 )
 

--- a/firmware/throttle/kia_soul_ps/throttle_control_module.ino
+++ b/firmware/throttle/kia_soul_ps/throttle_control_module.ino
@@ -70,7 +70,7 @@
 #define SPOOF_ENGAGE                    ( 6 )
 
 // Threshhold to detect when a person is pressing accelerator
-#define PEDAL_THRESH                    ( 1000 )
+#define PEDAL_THRESHOLD                 ( 1000 )
 
 // Threshhold to detect when there is a discrepancy between DAC and ADC values
 #define VOLTAGE_THRESHOLD               ( 0.096 )     // mV
@@ -280,7 +280,7 @@ void calculate_pedal_spoof( float pedal_target, struct torque_spoof_t* spoof )
 //
 void check_pedal_override( )
 {
-    if ( ( signal_L + signal_H ) / 2 > PEDAL_THRESH )
+    if ( ( signal_L + signal_H ) / 2 > PEDAL_THRESHOLD )
     {
         disable_control( );
         current_ctrl_state.override_flag.pedal = 1;


### PR DESCRIPTION
Prior to this pull request, the steering VOLTAGE_THRESHOLD was incorrectly set to 200V.  This commit corrects this typo, setting it to the correct value of 0.096V.  Also, "THRESH" is replaced with "THRESHOLD" per the style guide.