### PR TITLE
Fix timing and voltage issues in brake code

### DIFF
--- a/firmware/brake/kia_soul_ps/brake_control_module.ino
+++ b/firmware/brake/kia_soul_ps/brake_control_module.ino
@@ -56,7 +56,7 @@
 #define CAN_CS 53
 
 // ms
-#define PS_CTRL_RX_WARN_TIMEOUT ( 150 )
+#define PS_CTRL_RX_WARN_TIMEOUT ( 250 )
 
 // Braking PID windup guard
 #define BRAKE_PID_WINDUP_GUARD ( 500 )
@@ -165,7 +165,7 @@ const byte PIN_PFL  = 14;      // pressure front left sensor
 const double ZERO_PRESSURE = 0.48;        // The voltage the sensors read when no pressure is present
 const double MIN_PACC = 2.3;              // minumum accumulator pressure to maintain
 const double MAX_PACC = 2.4;              // max accumulator pressure to maintain
-const double PEDAL_THRESH = 0.6;          // Pressure for pedal interference
+const double PEDAL_THRESH = 0.7;          // Pressure for pedal interference
 
 int SLADutyMax,
     SLADutyMin,
@@ -695,8 +695,8 @@ void brakeUpdate()
                 brakes.powerSLA(calculateSLADutyCycle(pressurePID_output));
             }
 
-
-
+            // check pressures on master cylinder (pressure from pedal)
+            smc.checkPedal();
         }
     } 
     else if( pressure_req <= ZERO_PRESSURE ) 
@@ -811,9 +811,6 @@ void loop()
     publish_timed_tx_frames();
 
     check_rx_timeouts();
-
-    // check pressures on master cylinder (pressure from pedal)
-    smc.checkPedal();
 
     brakeStateMachine.update();
 }


### PR DESCRIPTION
Prior to this commit The RX time-out for brake command message was too low. 
This commit extends the timeout. Voltage drops cause the
pressure sensors to read higher voltages, this commit increases the
pedal pressure threshold to avoid an issue where pedal activity is
incorrectly detected during voltage drops. This code also moves the
function that checks for pedal input to only be called when braking is
occuring.