### PR TITLE
Increase command RX timeout

### DIFF
--- a/firmware/brake/kia_soul_ps/brake_control_module.ino
+++ b/firmware/brake/kia_soul_ps/brake_control_module.ino
@@ -56,7 +56,7 @@
 #define CAN_CS 53
 
 // ms
-#define PS_CTRL_RX_WARN_TIMEOUT ( 150 )
+#define PS_CTRL_RX_WARN_TIMEOUT ( 250 )
 
 // Braking PID windup guard
 #define BRAKE_PID_WINDUP_GUARD ( 500 )


### PR DESCRIPTION
Prior to this commit the command message timeout was 150ms which sometimes was triggered. This commit increases the timeout to be 250
which is consistent with the other modules.