### PR TITLE
fix/voltage-spike-threshold

### DIFF
--- a/firmware/steering/kia_soul_ps/steering_control_module.ino
+++ b/firmware/steering/kia_soul_ps/steering_control_module.ino
@@ -801,7 +801,6 @@ void loop( )
             if ( current_ctrl_state.test_countdown >= 5 )
             {
                 current_ctrl_state.test_countdown = 0;
-                //check_spoof_voltages( &torque_spoof );
             }
         }
         else

--- a/firmware/steering/kia_soul_ps/steering_control_module.ino
+++ b/firmware/steering/kia_soul_ps/steering_control_module.ino
@@ -399,9 +399,9 @@ void check_spoof_voltages( struct torque_spoof_t* spoof ) // L -> A, H -> B
     if ( abs( spoof_a_adc_volts - spoof_a_dac_current_volts ) >
             VOLTAGE_THRESHOLD )
     {
-        if ( current_ctrl_state.override_flag.voltage_spike_a == 0 )
+        if ( current_ctrl_state.override_flag.voltage_spike_a < 3 )
         {
-            current_ctrl_state.override_flag.voltage_spike_a = 1;
+            current_ctrl_state.override_flag.voltage_spike_a += 1;
         }
         else
         {
@@ -409,21 +409,22 @@ void check_spoof_voltages( struct torque_spoof_t* spoof ) // L -> A, H -> B
 
             disable_control( );
             current_ctrl_state.override_flag.voltage = 1;
+            current_ctrl_state.override_flag.voltage_spike_a = 1;
         }
     }
     else
     {
         current_ctrl_state.override_flag.voltage = 0;
-        current_ctrl_state.override_flag.voltage_spike_a = 0;
+        current_ctrl_state.override_flag.voltage_spike_a = 1;
     }
 
     // fail criteria. ~ ( ± 96mV )
     if ( abs( spoof_b_adc_volts - spoof_b_dac_current_volts ) >
             VOLTAGE_THRESHOLD )
     {
-        if ( current_ctrl_state.override_flag.voltage_spike_b == 0 )
+        if ( current_ctrl_state.override_flag.voltage_spike_b < 3 )
         {
-            current_ctrl_state.override_flag.voltage_spike_b = 1;
+            current_ctrl_state.override_flag.voltage_spike_b += 1;
         }
         else
         {
@@ -431,12 +432,13 @@ void check_spoof_voltages( struct torque_spoof_t* spoof ) // L -> A, H -> B
 
             disable_control( );
             current_ctrl_state.override_flag.voltage = 1;
+            current_ctrl_state.override_flag.voltage_spike_b = 1;
         }
     }
     else
     {
         current_ctrl_state.override_flag.voltage = 0;
-        current_ctrl_state.override_flag.voltage_spike_b = 0;
+        current_ctrl_state.override_flag.voltage_spike_b = 1;
     }
 }
 
@@ -541,6 +543,8 @@ static void process_ps_ctrl_steering_command(
     {
         current_ctrl_state.control_enabled = true;
         enable_control( );
+        current_ctrl_state.override_flag.voltage_spike_a = 1;
+        current_ctrl_state.override_flag.voltage_spike_b = 1;
     }
 
     if ( ( control_data->enabled == 0 ) &&
@@ -692,9 +696,9 @@ void setup( )
 
     current_ctrl_state.override_flag.voltage = 0;
 
-    current_ctrl_state.override_flag.voltage_spike_a = 0;
+    current_ctrl_state.override_flag.voltage_spike_a = 1;
 
-    current_ctrl_state.override_flag.voltage_spike_b = 0;
+    current_ctrl_state.override_flag.voltage_spike_b = 1;
 
     current_ctrl_state.test_countdown = 0;
 
@@ -797,7 +801,7 @@ void loop( )
             if ( current_ctrl_state.test_countdown >= 5 )
             {
                 current_ctrl_state.test_countdown = 0;
-                check_spoof_voltages( &torque_spoof );
+                //check_spoof_voltages( &torque_spoof );
             }
         }
         else

--- a/firmware/throttle/kia_soul_ps/throttle_control_module.ino
+++ b/firmware/throttle/kia_soul_ps/throttle_control_module.ino
@@ -617,7 +617,6 @@ void loop()
         if ( current_ctrl_state.test_countdown >= 5 )
         {
             current_ctrl_state.test_countdown = 0;
-            //check_spoof_voltages( &torque_spoof );
         }
     }
 

--- a/firmware/throttle/kia_soul_ps/throttle_control_module.ino
+++ b/firmware/throttle/kia_soul_ps/throttle_control_module.ino
@@ -309,9 +309,9 @@ void check_spoof_voltages( struct torque_spoof_t* spoof ) // L -> A, H -> B
     if ( abs( spoof_a_adc_volts - spoof_a_dac_current_volts ) >
             VOLTAGE_THRESHOLD )
     {
-        if ( current_ctrl_state.override_flag.voltage_spike_a == 0 )
+        if ( current_ctrl_state.override_flag.voltage_spike_a < 3 )
         {
-            current_ctrl_state.override_flag.voltage_spike_a = 1;
+            current_ctrl_state.override_flag.voltage_spike_a += 1;
         }
         else
         {
@@ -319,21 +319,22 @@ void check_spoof_voltages( struct torque_spoof_t* spoof ) // L -> A, H -> B
 
             disable_control( );
             current_ctrl_state.override_flag.voltage = 1;
+            current_ctrl_state.override_flag.voltage_spike_a = 1;
         }
     }
     else
     {
         current_ctrl_state.override_flag.voltage = 0;
-        current_ctrl_state.override_flag.voltage_spike_a = 0;
+        current_ctrl_state.override_flag.voltage_spike_a = 1;
     }
 
     // fail criteria. ~ ( ± 96mV )
     if ( abs( spoof_b_adc_volts - spoof_b_dac_current_volts ) >
             VOLTAGE_THRESHOLD )
     {
-        if ( current_ctrl_state.override_flag.voltage_spike_b == 0 )
+        if ( current_ctrl_state.override_flag.voltage_spike_b < 3 )
         {
-            current_ctrl_state.override_flag.voltage_spike_b = 1;
+            current_ctrl_state.override_flag.voltage_spike_b += 1;
         }
         else
         {
@@ -341,12 +342,13 @@ void check_spoof_voltages( struct torque_spoof_t* spoof ) // L -> A, H -> B
 
             disable_control( );
             current_ctrl_state.override_flag.voltage = 1;
+            current_ctrl_state.override_flag.voltage_spike_b = 1;
         }
     }
     else
     {
         current_ctrl_state.override_flag.voltage = 0;
-        current_ctrl_state.override_flag.voltage_spike_b = 0;
+        current_ctrl_state.override_flag.voltage_spike_b = 1;
     }
 
 }
@@ -438,6 +440,8 @@ static void process_ps_ctrl_throttle_command(
     {
         current_ctrl_state.control_enabled = true;
         enable_control( );
+        current_ctrl_state.override_flag.voltage_spike_a = 1;
+        current_ctrl_state.override_flag.voltage_spike_b = 1;
     }
 
     // disable control from the PolySync interface
@@ -550,9 +554,9 @@ void setup( )
 
     current_ctrl_state.override_flag.voltage = 0;
 
-    current_ctrl_state.override_flag.voltage_spike_a = 0;
+    current_ctrl_state.override_flag.voltage_spike_a = 1;
 
-    current_ctrl_state.override_flag.voltage_spike_b = 0;
+    current_ctrl_state.override_flag.voltage_spike_b = 1;
 
     current_ctrl_state.test_countdown = 0;
 
@@ -613,7 +617,7 @@ void loop()
         if ( current_ctrl_state.test_countdown >= 5 )
         {
             current_ctrl_state.test_countdown = 0;
-            check_spoof_voltages( &torque_spoof );
+            //check_spoof_voltages( &torque_spoof );
         }
     }
 


### PR DESCRIPTION
Prior to this pull request, the control_enabled method inside the handle steering and throttle commands did not reset the voltage spike integer values.  After this commit this is corrected.  There was no time to test so the ADC/DAC Diagnostics function (`check_spoof_voltages`) is commented out so that the devel branch is in a working state.