### PR TITLE
Fix throttle pedal disable flag

### DIFF
--- a/firmware/throttle/kia_soul_ps/throttle_control_module.ino
+++ b/firmware/throttle/kia_soul_ps/throttle_control_module.ino
@@ -591,11 +591,12 @@ void loop()
     signal_L = analogRead( SIGNAL_INPUT_A ) << 2;  //10 bit to 12 bit
     signal_H = analogRead( SIGNAL_INPUT_B ) << 2;
 
+    // if someone is pressing the throttle pedal, disable control
+    check_pedal_override( );
+
     // now that we've set control status, do throttle if we are in control
     if ( current_ctrl_state.control_enabled == true )
     {
-        // if someone is pressing the throttle pedal, disable control
-        check_pedal_override( );
 
         struct torque_spoof_t torque_spoof;
 


### PR DESCRIPTION
Prior to this commit control could no be re-enabled after the throttle pedal was depressed because the logic only executed if control was enabled. This commit moves
the check_pedal function outside of the logic block and
always checks wheel input in the loop, similar to brake and steering