### PR TITLE
Use exlusive access macro instead of hexidecimal value as canOpenChannel flag

### DIFF
--- a/control/joystick_commander/src/node.c
+++ b/control/joystick_commander/src/node.c
@@ -184,7 +184,7 @@ static int init_can( int can_channel_index, canHandle* handle )
     
     if( ret == NOERR )
     {
-        (*handle) = canOpenChannel( can_channel_index, 0x40 );
+        (*handle) = canOpenChannel( can_channel_index, canOPEN_EXCLUSIVE );
 
         if ( (*handle) < 0 ) 
         {


### PR DESCRIPTION
Prior to this commit we pass a hexidecimal value to canOpenChannel(). This value caused an issue on two new machines running the joystick commander where the application could not open the CAN channel. This commit uses the macro for exclusive can channel access to fix the problem.

This has been tested on a Kia with two different machines running joystick commander.