### PR TITLE
Add driver override to steering module

### DIFF
--- a/firmware/steering/kia_soul_ps/steering_control_module.ino
+++ b/firmware/steering/kia_soul_ps/steering_control_module.ino
@@ -402,14 +402,9 @@ bool check_driver_steering_override( )
         ( torque_filter_alpha * torque_sensor_b ) +
             ( ( 1.0 - torque_filter_alpha ) * filtered_torque_b );
 
-    Serial.print( filtered_torque_a );
-    Serial.print( " " );
-    Serial.println( filtered_torque_b );
-
     if ( ( abs( filtered_torque_a ) > steering_wheel_max_torque ) ||
          ( abs( filtered_torque_b ) > steering_wheel_max_torque ) )
     {
-        Serial.println( "Exceeded max torque" );
         override = true;
     }
 

--- a/firmware/steering/kia_soul_ps/steering_control_module.ino
+++ b/firmware/steering/kia_soul_ps/steering_control_module.ino
@@ -383,6 +383,21 @@ void disable_control( )
 // *****************************************************
 bool check_driver_steering_override( )
 {
+    // The parameters below; torque_filter_alpha and steering_wheel_max_torque,
+    // can be used to modify how selective the steering override functionality
+    // is. If torque_filter_alpha or steering_wheel_max_torque is increased
+    // then steering override will be more selective about disabling on driver
+    // input. That is, it will require a harder input for the steering wheel
+    // to automatically disable. If these values are lowered then the steering
+    // override will be less selective; this may result in drastic movements
+    // of the joystick controller triggering steering override. 
+    // It is expected behavior that if a user uses the joystick controller to
+    // purposefully "fight" the direction of steering wheel movement that this
+    // will cause a steering override with the below parameters. That is if
+    // the steering wheel is drastically "jerked" back and forth, opposing the
+    // direction of steering wheel movement and purposefully trying to cause
+    // an unstable situation, the steering override is expected to be 
+    // triggered.
     static const float torque_filter_alpha = 0.5;
     static const float steering_wheel_max_torque = 3000.0;
 


### PR DESCRIPTION
Prior to this commit we didn't have a good way of disabling on driver override on steering wheel. This commit adds the functionality to detect a driver override on steering wheel, and then disable properly.