### PR TITLE
Fix timeout steering command CAN message RX

### DIFF
--- a/firmware/steering/kia_soul_ps/steering_control_module.ino
+++ b/firmware/steering/kia_soul_ps/steering_control_module.ino
@@ -48,7 +48,7 @@
 #define CAN_CS                          ( 10 )
 
 // ms
-#define PS_CTRL_RX_WARN_TIMEOUT         ( 2500 )
+#define PS_CTRL_RX_WARN_TIMEOUT         ( 250 )
 
 // set up pins for interface with DAC (MCP4922)
 #define DAC_CS                          ( 9 )       // Chip select pin


### PR DESCRIPTION
Prior to this commit the timeout for receiving steering command was too large. This commit changes this timeout to a reasonable value.