### PR TITLE
Fix brake module header

### DIFF
--- a/firmware/brake/kia_soul_ps/brake_control_module.ino
+++ b/firmware/brake/kia_soul_ps/brake_control_module.ino
@@ -17,14 +17,11 @@
 /* along with OSCC.  If not, see <http://www.gnu.org/licenses/>.        */
 /************************************************************************/
 
-// Throttle control ECU firmware
-// Firmware for control of 2014 Kia Soul throttle system
-// Component
-//    Arduino Mega
-//    Seeed Studio CAN-BUS Shield, v1.2 (MCP2515)
-//    Sainsmart 4 relay module
-//    6 channel mosfet Board
-// E Livingston, 2016
+// Brake control ECU firmware
+// 2004-2009 Prius brake actuator
+
+
+
 
 #include <SPI.h>
 #include <FiniteStateMachine.h>


### PR DESCRIPTION
Prior to this commit the brake module header was incorrect and outdated. This commit fixes the brake module header.