### PR TITLE
Fix CAN gateway source header

### DIFF
--- a/firmware/can_gateway/kia_soul_ps/can_gateway.ino
+++ b/firmware/can_gateway/kia_soul_ps/can_gateway.ino
@@ -27,8 +27,8 @@
 /************************************************************************/
 
 /**
- * @file vehicle_gateway_module.ino
- * @brief Vehicle Gateway Module Source.
+ * @file can_gateway.ino
+ * @brief CAN Gateway Module Source.
  *
  * Board: Arduino Uno
  * Arduino Build/Version: 1.6.7 linux-x86_64


### PR DESCRIPTION
Prior to this commit the header of the CAN gateway source was incorrect/outdated. This commit updates the CAN gateway header to be correct.