### PR TITLE
Fix command message  timeout for throttle module

### DIFF
--- a/firmware/throttle/kia_soul_ps/throttle_control_module.ino
+++ b/firmware/throttle/kia_soul_ps/throttle_control_module.ino
@@ -49,7 +49,7 @@
 #define CAN_CS                          ( 10 )
 
 // ms
-#define PS_CTRL_RX_WARN_TIMEOUT         ( 2500 )
+#define PS_CTRL_RX_WARN_TIMEOUT         ( 250 )
 
 // set up pins for interface with DAC (MCP4922)
 #define DAC_CS                          ( 9 )       // Chip select pin


### PR DESCRIPTION
Prior to this commit the time-out for the throttle module was far too high at 2500 ms. This commit reduces the time-out for the throttle module down to 250 ms.