### PR TITLE
Add filter to PACC pressure reading

### DIFF
--- a/firmware/brake/kia_soul_ps/Makefile
+++ b/firmware/brake/kia_soul_ps/Makefile
@@ -30,19 +30,38 @@
 ##########################################################
 
 #
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Linux)
+    OSFLAG = LINUX
+endif
+ifeq ($(UNAME_S),Darwin)
+    OSFLAG = OSX
+endif
+
+#
 PROJECT_DIR := $(shell pwd)
 
 #
 ARDMK_DIR = $(PROJECT_DIR)/../../arduino_make
 
-#
-ARDUINO_DIR = /usr/share/arduino
+ifeq ($(OSFLAG), LINUX)
+    ARDUINO_DIR = /usr/share/arduino
+
+    BOARD_TAG = mega2560
+
+    AVRDUDE = /usr/bin/avrdude
+endif
+ifeq ($(OSFLAG), OSX)
+    ARDUINO_DIR=/Applications/Arduino.app/Contents/Java/
+
+    BOARD_TAG = mega
+    BOARD_SUB = atmega2560
+
+    AVRDUDE = /usr/local/bin/avrdude
+endif
 
 #
 USER_LIB_PATH = $(PROJECT_DIR)/../../arduino_libraries
-
-#
-BOARD_TAG = mega2560
 
 #
 MONITOR_BAUDRATE = 115200

--- a/firmware/brake/kia_soul_ps/brake_control_module.ino
+++ b/firmware/brake/kia_soul_ps/brake_control_module.ino
@@ -264,7 +264,7 @@ struct Accumulator {
     // Purpose:     This function checks the voltage input from the accumulator
     //              pressure sensor to determine if the accumulator pump should
     //              be powered on or powered off. The accumulator should maintain
-    //              enough pressure to emergency break at any point.
+    //              enough pressure to emergency brake at any point.
     //
     //              Because analog voltage sensors are being read, a filter is applied
     //              to the reading to ensure that voltage drops/spikes don't effect

--- a/firmware/brake/kia_soul_ps/brake_control_module.ino
+++ b/firmware/brake/kia_soul_ps/brake_control_module.ino
@@ -249,29 +249,53 @@ struct Accumulator {
     // turn relay on or off
     void pumpOn()
     {
-      digitalWrite(_controlPin, HIGH);
+        digitalWrite(_controlPin, HIGH);
     }
 
 
     void pumpOff()
     {
-      digitalWrite(_controlPin, LOW);
+        digitalWrite(_controlPin, LOW);
     }
 
-    // maintain accumulator pressure
+    // *****************************************************
+    // Function:    maintainPressure()
+    //
+    // Purpose:     This function checks the voltage input from the accumulator
+    //              pressure sensor to determine if the accumulator pump should
+    //              be powered on or powered off. The accumulator should maintain
+    //              enough pressure to emergency break at any point.
+    //
+    //              Because analog voltage sensors are being read, a filter is applied
+    //              to the reading to ensure that voltage drops/spikes don't effect
+    //              the reading.
+    //
+    //
+    // Returns:     void
+    //
+    // Parameters:  None
+    //
+    // *****************************************************
     void maintainPressure()
     {
-      _pressure = convertToVoltage(analogRead(_sensorPin));
+        static const float filter_alpha = 0.05;
+        static float _pressure = 0.0;
 
-      if( _pressure < MIN_PACC )
-      {
-          pumpOn();
-      }
+        // This is going to get filtered
+        float sensor_1 = convertToVoltage(analogRead(_sensorPin));
 
-      if( _pressure > MAX_PACC )
-      {
-          pumpOff();
-      }
+        _pressure = ( filter_alpha * sensor_1 ) +
+            ( ( 1.0 - filter_alpha ) * _pressure );
+
+        if( _pressure < MIN_PACC )
+        {
+            pumpOn();
+        }
+
+        if( _pressure > MAX_PACC )
+        {
+            pumpOff();
+        }
     }
 };
 


### PR DESCRIPTION
Prior to this commit the maintainPressure() function could cause the actuator to become overpressurized if a pressure reading was taken
during a voltage spike/drop. This commit adds a filter to the pressure
reading to avoid anomolies. This commit also updates the Makefile to
work with OSX