### PR TITLE
remove auto pump from test firmware

### DIFF
--- a/firmware/brake/tests/brake_controller/brake_controller_r0_test.ino
+++ b/firmware/brake/tests/brake_controller/brake_controller_r0_test.ino
@@ -660,7 +660,7 @@ void waitEnter()
 void waitUpdate()
 {
     // keep accumulator pressurized
-    accumulator.maintainPressure();
+    //accumulator.maintainPressure();
 
     // TODO: Is this check needed? Don't we force transition elsewhere?
     if( pressure_req > ZERO_PRESSURE + .01 )
@@ -687,7 +687,7 @@ void brakeEnter() {
 void brakeUpdate()
 {
     // maintain accumulator pressure
-    accumulator.maintainPressure();
+    //accumulator.maintainPressure();
 
     // calculate a delta t
     lastMicros = currMicros;


### PR DESCRIPTION
Prior to this commit the test firmware for the brake actuator maintained pump pressure. In order to make the test firmware more usable on a bench (without a brake fluid reservoir) the lines to maintain pump pressure have been commented out.