### PR TITLE
fix/broken-make-pointer

### DIFF
--- a/firmware/brake/tests/brake_bench/Makefile
+++ b/firmware/brake/tests/brake_bench/Makefile
@@ -6,13 +6,13 @@
 PROJECT_DIR := $(shell pwd)
 
 #
-ARDMK_DIR = $(PROJECT_DIR)/../../arduino_make
+ARDMK_DIR = $(PROJECT_DIR)/../../../arduino_make
 
 #
 ARDUINO_DIR = /usr/share/arduino
 
 #
-USER_LIB_PATH = $(PROJECT_DIR)/../../arduino_libraries
+USER_LIB_PATH = $(PROJECT_DIR)/../../../arduino_libraries
 
 #
 BOARD_TAG = mega2560

--- a/firmware/brake/tests/brake_controller/Makefile
+++ b/firmware/brake/tests/brake_controller/Makefile
@@ -6,13 +6,13 @@
 PROJECT_DIR := $(shell pwd)
 
 #
-ARDMK_DIR = $(PROJECT_DIR)/../../arduino_make
+ARDMK_DIR = $(PROJECT_DIR)/../../../arduino_make
 
 #
 ARDUINO_DIR = /usr/share/arduino
 
 #
-USER_LIB_PATH = $(PROJECT_DIR)/../../arduino_libraries
+USER_LIB_PATH = $(PROJECT_DIR)/../../../arduino_libraries
 
 #
 BOARD_TAG = mega2560

--- a/firmware/steering/tests/dac_adc_diagnostics/Makefile
+++ b/firmware/steering/tests/dac_adc_diagnostics/Makefile
@@ -6,13 +6,13 @@
 PROJECT_DIR := $(shell pwd)
 
 #
-ARDMK_DIR = $(PROJECT_DIR)/../../arduino_make
+ARDMK_DIR = $(PROJECT_DIR)/../../../arduino_make
 
 #
 ARDUINO_DIR = /usr/share/arduino
 
 #
-USER_LIB_PATH = $(PROJECT_DIR)/../../arduino_libraries
+USER_LIB_PATH = $(PROJECT_DIR)/../../../arduino_libraries
 
 #
 BOARD_TAG = uno

--- a/firmware/steering/tests/steering_controller/Makefile
+++ b/firmware/steering/tests/steering_controller/Makefile
@@ -6,13 +6,13 @@
 PROJECT_DIR := $(shell pwd)
 
 #
-ARDMK_DIR = $(PROJECT_DIR)/../../arduino_make
+ARDMK_DIR = $(PROJECT_DIR)/../../../arduino_make
 
 #
 ARDUINO_DIR = /usr/share/arduino
 
 #
-USER_LIB_PATH = $(PROJECT_DIR)/../../arduino_libraries
+USER_LIB_PATH = $(PROJECT_DIR)/../../../arduino_libraries
 
 #
 BOARD_TAG = uno


### PR DESCRIPTION
Prior to this pull request, the Makefiles for each of the tests did not compile due to an invalid directory reference.  This commit corrects that by properly referencing the arduino make directories.