### PR TITLE
Add link to coding standard

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ Below is a sample of how additional vehicle directories should be created.
 
 ### Contributing Code
 
-- Code should conform to the coding standard (see below)
+- Code should conform to the [coding standard](#oscc-coding-standard)
 - Push your changes to a topic branch in your branch of the repository
 - Submit a pull request to the repository in the PolySync organization
 - Update your github issue to mark that you have submitted code and are ready for it to be reviewed (Status: Ready for Merge)


### PR DESCRIPTION
Prior to this commit we referenced the coding standard in the contributing section but did
not link directly to it. This commit links directly to the coding standard to ease burden for
contributors.