### PR TITLE
Add warning to steering control state struct

### DIFF
--- a/firmware/steering/kia_soul_ps/current_control_state.h
+++ b/firmware/steering/kia_soul_ps/current_control_state.h
@@ -66,6 +66,21 @@ typedef struct
     double PID_setpoint; /* Setpoint for PID controller */
     //
     //
+/*******************************************************************************
+*   WARNING
+*
+*   The PID gains (SA_Kp, SA_Ki, SA_Kd) are carefully tested to ensure that a
+*   torque is not requested that the vehicles steering motor cannot handle.
+*   By changing any of this code you risk attempting to actuate
+*   a torque outside of the vehicles valid range. Actuating a torque outside of
+*   the vehicles valid range will, at best, cause the vehicle to go into an
+*   unrecoverable fault state. Clearing this fault state requires one of Kia's
+*   native diagnostics tools, and someone who knows how to clear DTC codes with
+*   said tool.
+*
+*   It is NOT recommended to modify any of the existing control ranges, or
+*   gains, without expert knowledge.
+*******************************************************************************/
     double SA_Kp = 0.3; /* Proportional gain for PID controller */
     //
     //


### PR DESCRIPTION
Prior to this commit, there was no warning for the PID numbers in the
current control state struct for the steering control module.  Users
have been faulting their cars by possibly making changes to these
numbers.  This commit adds in the warning in an attempt to lower the
number of faults by including a warning.