### PR TITLE
Update copyright; update the help reference link

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,8 +176,8 @@ Please see [LICENSE.md](LICENSE.md) for more details.
 Contact Information
 -------------------
 
-Please direct questions regarding OSCC and/or licensing to help@polysync.io.
+Please direct questions regarding OSCC and/or licensing to the OSCC GitHub Issues section: https://github.com/PolySync/OSCC/issues.
 
 *Distributed as-is; no warranty is given.*
 
-Copyright (c) 2016 PolySync Technologies, Inc.  All Rights Reserved.
+Copyright (c) 2017 PolySync Technologies, Inc.  All Rights Reserved.


### PR DESCRIPTION
Updated the README to inform engineers that all questions and comments
should be posted in the GitHub "Issues" page rather than emailing the
PolySync support desk.

Updated the copyright year to 2017.