### PR TITLE
Restore `make monitor` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,14 +123,18 @@ with the following command:
 sudo apt install screen
 ```
 
-You can connect to the serial interface (assuming a port of `/dev/ttyACM0` and a baudrate of
-`115200`) with the following command:
+You can use `make monitor` to automatically run `screen`, or `make monitor-log`
+to run `screen` and output to a file called `screenlog.0` in your current directory:
 
 ```
-screen /dev/ttyACM0 115200
+make monitor
+make monitor-log
 ```
 
-You can exit screen with `C-a \`.
+The serial port and baudrate to use can be configured in `platforms/CMakeLists.txt`
+by modifying `ARDUINO_DEFAULT_PORT` and `ARDUINO_DEFAULT_BAUDRATE`.
+
+You can exit `screen` with `C-a \`.
 
 To do more in-depth debugging you can use any of a number of serial monitoring applications.
 Processing can be used quite effectively to provide output plots of data incoming across a serial

--- a/platforms/CMakeLists.txt
+++ b/platforms/CMakeLists.txt
@@ -26,10 +26,21 @@ else()
 
     project(firmware)
 
-    set(ARDUINO_DEFAULT_PORT /dev/ttyACM0)
-
     option(DEBUG "Enable debug mode" OFF)
     option(BUILD_KIA_SOUL "Build firmware for Kia Soul" OFF)
+
+    set(ARDUINO_DEFAULT_PORT /dev/ttyACM0)
+    set(ARDUINO_DEFAULT_BAUDRATE 115200)
+
+    add_definitions(-DSERIAL_BAUD=${ARDUINO_DEFAULT_BAUDRATE})
+
+    add_custom_target(
+        monitor
+        COMMAND screen ${ARDUINO_DEFAULT_PORT} ${ARDUINO_DEFAULT_BAUDRATE})
+
+    add_custom_target(
+        monitor-log
+        COMMAND screen -L ${ARDUINO_DEFAULT_PORT} ${ARDUINO_DEFAULT_BAUDRATE})
 
     if(DEBUG)
         add_definitions(-DDEBUG)

--- a/platforms/common/libs/serial/oscc_serial.h
+++ b/platforms/common/libs/serial/oscc_serial.h
@@ -9,13 +9,6 @@
 #define _OSCC_SERIAL_H_
 
 
-/*
- * @brief Serial baudrate.
- *
- */
-#define SERIAL_BAUD (115200)
-
-
 // ****************************************************************************
 // Function:    init_serial
 //


### PR DESCRIPTION
Prior to this commit, the `make monitor` command from the previous
Makefile-based build system was missing which led to painful monitoring
of serial output by manually invoking `screen` every time. This commit
adds the custom target `monitor` which runs normal `screen`, and the
custom target `monitor-log` which runs `screen` but prints the serial
output to a file called `screenlog.0`.