### PR TITLE
Create make target to run all tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
-# 3D Files #
-############
+# 3D Files
 *.bfb
 *.cubepro
+
+
+# Cargo build files
+**/tests/**/Cargo.lock
+**/tests/**/common/
+**/tests/**/target/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,13 +21,10 @@ node('arduino') {
     }
     stage('Test') {
       parallel 'unit tests': {
-        sh 'cd platforms && mkdir build_tests && cd build_tests && cmake .. -DTESTS=ON -DCMAKE_BUILD_TYPE=Release && make run-tests'
+        sh 'cd platforms && mkdir build_unit_tests && cd build_unit_tests && cmake .. -DTESTS=ON -DCMAKE_BUILD_TYPE=Release && make run-unit-tests'
         echo 'Unit Tests Complete!'
       }, 'property-based tests': {
-        sh 'cargo test --manifest-path platforms/kia_soul/firmware/steering/tests/property/Cargo.toml -- --test-threads=1'
-        sh 'cargo test --manifest-path platforms/kia_soul/firmware/brake/tests/property/Cargo.toml -- --test-threads=1'
-        sh 'cargo test --manifest-path platforms/kia_soul/firmware/throttle/tests/property/Cargo.toml -- --test-threads=1'
-        sh 'cargo test --manifest-path platforms/common/libs/pid/tests/property/Cargo.toml'
+        sh 'cd platforms && mkdir build_property_tests && cd build_property_tests && cmake .. -DTESTS=ON -DCMAKE_BUILD_TYPE=Release && make run-property-tests'
         echo 'Property-Based Tests Complete!'
       }, 'acceptance tests': {
         echo 'Acceptance Tests Complete!'

--- a/README.md
+++ b/README.md
@@ -144,8 +144,25 @@ Be aware that using serial printing can affect the timing of the firmware. You m
 strange behavior while printing that does not occur otherwise.
 
 
-Unit Tests
+Tests
 ------------
+
+There are two types of tests available: unit and property-based.
+
+Building and running the tests is similar to the firmware itself, but you must instead tell
+CMake to build the tests instead of the firmware with the `-DTESTS=ON` flag. We also pass
+the `-DCMAKE_BUILD_TYPE=Release` flag so that CMake will disable debug symbols and enable
+optimizations, good things to do when running tests to ensure nothing breaks with
+optimizations.
+
+```
+cd platforms
+mkdir build
+cd build
+cmake .. -DTESTS=ON -DCMAKE_BUILD_TYPE=Release
+```
+
+**Unit Tests**
 
 Each module has a suite of unit tests that use **Cucumber** with **Cgreen**. There are prebuilt
 64-bit Linux versions in `platforms/common/testing/framework`. Boost is required for Cucumber-CPP
@@ -157,9 +174,6 @@ in an `oscc_test_framework` directory in the directory that you ran the script f
 `oscc_test_framework/cucumber-cpp` and `oscc_test_framework/cgreen` to
 `platforms/common/testing/framework`.
 
-
-**Running the Tests**
-
 You must have **Cucumber** installed to run the tests:
 
 ```
@@ -167,40 +181,25 @@ sudo apt install ruby-dev
 sudo gem install cucumber -v 2.0.0
 ```
 
-Building and running the tests is similar to the firmware itself, but you must instead tell
-CMake to build the tests instead of the firmware with the `-DTESTS=ON` flag. We also pass
-the `-DCMAKE_BUILD_TYPE=Release` flag so that CMake will disable debug symbols and enable
-optimizations, good things to do when running tests to ensure nothing breaks with
-optimizations.
-
-We first need a build directory in the `platforms` directory:
+We can run all of the unit tests available:
 
 ```
-cd platforms
-mkdir build
-cd build
-```
-
-Then we tell CMake that we're going to be building tests:
-
-```
-cmake .. -DTESTS=ON -DCMAKE_BUILD_TYPE=Release
-```
-
-Finally we make the `run-tests` target which will build the tests for each module and
-run them:
-
-```
-make run-tests
+make run-unit-tests
 ```
 
 Each module's test can also be run individually:
 
 ```
-make run-brake-tests
-make run-can-gateway-tests
-make run-steering-tests
-make run-throttle-tests
+make run-kia-soul-brake-unit-tests
+make run-kia-soul-can-gateway-unit-tests
+make run-kia-soul-steering-unit-tests
+make run-kia-soul-throttle-unit-tests
+```
+
+Or run only the tests of a single platform:
+
+```
+make run-kia-soul-unit-tests
 ```
 
 If everything works correctly you should see something like this:
@@ -228,39 +227,35 @@ Feature: Receiving commands
       | 1024       | 4096      | 4096      |
 ```
 
-
-Property-Based Tests
-------------
+**Property-Based Tests**
 
 The throttle, steering, and brake modules, along with the PID controller library, also contain a series of
-property based tests.
-These tests use [QuickCheck for Rust](http://burntsushi.net/rustdoc/quickcheck/), so **Rust** and **Cargo** 
+property-based tests.
+
+These tests use [QuickCheck for Rust](http://burntsushi.net/rustdoc/quickcheck/), so **Rust** and **Cargo**
 need to be [installed](https://www.rust-lang.org/en-US/install.html) in order to run them locally.
 
 
-**Running the Tests**
-
-To run the tests, first navigate into the folder of the module to be tested.
-For example, to run the PID tests: 
+We can run all of the property-based tests available:
 
 ```
-cd platforms/common/libs/pid/tests/property
+make run-property-tests
 ```
 
-Cargo is then used to build the tests, including fetching any needed dependencies:
+Each module's test can also be run individually:
 
 ```
-cargo build
+make run-kia-soul-brake-property-tests
+make run-kia-soul-steering-property-tests
+make run-kia-soul-throttle-property-tests
+make run-pid-library-property-tests
 ```
 
-The property based tests are also run by Cargo:
+Or run only the tests of a single platform:
 
 ```
-cargo test -- --test-threads=1
+make run-kia-soul-property-tests
 ```
-
-*(note: If you are running the property-based tests on the firmware modules, the test-threads argument is required to
-prevent data corruption. If you are running the tests on the PID controller, it can be safely omitted.)*
 
 Once the tests have completed, the output should look similar to the following:
 
@@ -281,6 +276,14 @@ test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured
 running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
+```
+
+**Run All Tests**
+
+Finally, you can run all available tests:
+
+```
+make run-all-tests
 ```
 
 

--- a/platforms/CMakeLists.txt
+++ b/platforms/CMakeLists.txt
@@ -11,14 +11,44 @@ if(TESTS)
     add_subdirectory(kia_soul/firmware/can_gateway/tests)
     add_subdirectory(kia_soul/firmware/steering/tests)
     add_subdirectory(kia_soul/firmware/throttle/tests)
+    add_subdirectory(common/libs/pid/tests)
 
     add_custom_target(
-        run-tests
+        run-kia-soul-unit-tests
         DEPENDS
-        run-brake-tests
-        run-can-gateway-tests
-        run-steering-tests
-        run-throttle-tests)
+        run-kia-soul-brake-unit-tests
+        run-kia-soul-can-gateway-unit-tests
+        run-kia-soul-steering-unit-tests
+        run-kia-soul-throttle-unit-tests)
+
+    add_custom_target(
+        run-kia-soul-property-tests
+        DEPENDS
+        run-kia-soul-brake-property-tests
+        run-kia-soul-steering-property-tests
+        run-kia-soul-throttle-property-tests)
+
+    add_custom_target(
+        run-library-property-tests
+        DEPENDS
+        run-pid-library-property-tests)
+
+    add_custom_target(
+        run-unit-tests
+        DEPENDS
+        run-kia-soul-unit-tests)
+
+    add_custom_target(
+        run-property-tests
+        DEPENDS
+        run-kia-soul-property-tests
+        run-library-property-tests)
+
+    add_custom_target(
+        run-all-tests
+        DEPENDS
+        run-unit-tests
+        run-property-tests)
 else()
     set(CMAKE_TOOLCHAIN_FILE common/toolchain/ArduinoToolchain.cmake)
 

--- a/platforms/common/libs/pid/tests/CMakeLists.txt
+++ b/platforms/common/libs/pid/tests/CMakeLists.txt
@@ -1,0 +1,7 @@
+project(pid-library-tests)
+
+add_custom_target(
+    run-pid-library-property-tests
+    COMMAND
+    cargo test -- --test-threads=1
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/property)

--- a/platforms/kia_soul/firmware/brake/tests/CMakeLists.txt
+++ b/platforms/kia_soul/firmware/brake/tests/CMakeLists.txt
@@ -28,18 +28,18 @@ target_include_directories(
     ${CMAKE_SOURCE_DIR}/common/testing/mocks)
 
 add_executable(
-    kia-soul-brake-test
+    kia-soul-brake-unit-test
     features/step_definitions/test.cpp)
 
 target_link_libraries(
-    kia-soul-brake-test
+    kia-soul-brake-unit-test
     PRIVATE
     kia-soul-brake
     ${CMAKE_SOURCE_DIR}/common/testing/framework/cucumber-cpp/lib/libcucumber-cpp.a
     ${CMAKE_SOURCE_DIR}/common/testing/framework/cgreen/lib/libcgreen.so)
 
 target_include_directories(
-    kia-soul-brake-test
+    kia-soul-brake-unit-test
     PRIVATE
     ../include
     ${CMAKE_SOURCE_DIR}/common/include
@@ -50,8 +50,14 @@ target_include_directories(
     ${CMAKE_SOURCE_DIR}/common/testing/framework/cgreen/include)
 
 add_custom_target(
-    run-brake-tests
+    run-kia-soul-brake-unit-tests
     DEPENDS
-    kia-soul-brake-test
+    kia-soul-brake-unit-test
     COMMAND
-    kia-soul-brake-test --port=3902 >/dev/null & cucumber _2.0.0_ ${CMAKE_CURRENT_SOURCE_DIR}/features )
+    kia-soul-brake-unit-test --port=3902 >/dev/null & cucumber _2.0.0_ ${CMAKE_CURRENT_SOURCE_DIR}/features )
+
+add_custom_target(
+    run-kia-soul-brake-property-tests
+    COMMAND
+    cargo test -- --test-threads=1
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/property)

--- a/platforms/kia_soul/firmware/can_gateway/tests/CMakeLists.txt
+++ b/platforms/kia_soul/firmware/can_gateway/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(kia-soul-can-gateway-tests)
+project(kia-soul-can-gateway-unit-tests)
 
 add_library(
     kia-soul-can-gateway
@@ -20,18 +20,18 @@ target_include_directories(
     ${CMAKE_SOURCE_DIR}/common/testing/mocks)
 
 add_executable(
-    kia-soul-can-gateway-test
+    kia-soul-can-gateway-unit-test
     features/step_definitions/test.cpp)
 
 target_link_libraries(
-    kia-soul-can-gateway-test
+    kia-soul-can-gateway-unit-test
     PRIVATE
     kia-soul-can-gateway
     ${CMAKE_SOURCE_DIR}/common/testing/framework/cucumber-cpp/lib/libcucumber-cpp.a
     ${CMAKE_SOURCE_DIR}/common/testing/framework/cgreen/lib/libcgreen.so)
 
 target_include_directories(
-    kia-soul-can-gateway-test
+    kia-soul-can-gateway-unit-test
     PRIVATE
     ../include
     ${CMAKE_SOURCE_DIR}/common/include
@@ -41,8 +41,8 @@ target_include_directories(
     ${CMAKE_SOURCE_DIR}/common/testing/framework/cgreen/include)
 
 add_custom_target(
-    run-can-gateway-tests
+    run-kia-soul-can-gateway-unit-tests
     DEPENDS
-    kia-soul-can-gateway-test
+    kia-soul-can-gateway-unit-test
     COMMAND
-    kia-soul-can-gateway-test --port=3902 >/dev/null & cucumber _2.0.0_ ${CMAKE_CURRENT_SOURCE_DIR}/features )
+    kia-soul-can-gateway-unit-test --port=3902 >/dev/null & cucumber _2.0.0_ ${CMAKE_CURRENT_SOURCE_DIR}/features )

--- a/platforms/kia_soul/firmware/steering/tests/CMakeLists.txt
+++ b/platforms/kia_soul/firmware/steering/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(kia-soul-steering-tests)
+project(kia-soul-steering-unit-tests)
 
 add_library(
     kia-soul-steering
@@ -29,18 +29,18 @@ target_include_directories(
     ${CMAKE_SOURCE_DIR}/common/testing/mocks)
 
 add_executable(
-    kia-soul-steering-test
+    kia-soul-steering-unit-test
     features/step_definitions/test.cpp)
 
 target_link_libraries(
-    kia-soul-steering-test
+    kia-soul-steering-unit-test
     PRIVATE
     kia-soul-steering
     ${CMAKE_SOURCE_DIR}/common/testing/framework/cucumber-cpp/lib/libcucumber-cpp.a
     ${CMAKE_SOURCE_DIR}/common/testing/framework/cgreen/lib/libcgreen.so)
 
 target_include_directories(
-    kia-soul-steering-test
+    kia-soul-steering-unit-test
     PRIVATE
     ../include
     ${CMAKE_SOURCE_DIR}/common/include
@@ -51,8 +51,14 @@ target_include_directories(
     ${CMAKE_SOURCE_DIR}/common/testing/framework/cgreen/include)
 
 add_custom_target(
-    run-steering-tests
+    run-kia-soul-steering-unit-tests
     DEPENDS
-    kia-soul-steering-test
+    kia-soul-steering-unit-test
     COMMAND
-    kia-soul-steering-test --port=3902 >/dev/null & cucumber _2.0.0_ ${CMAKE_CURRENT_SOURCE_DIR}/features )
+    kia-soul-steering-unit-test --port=3902 >/dev/null & cucumber _2.0.0_ ${CMAKE_CURRENT_SOURCE_DIR}/features )
+
+add_custom_target(
+    run-kia-soul-steering-property-tests
+    COMMAND
+    cargo test -- --test-threads=1
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/property)

--- a/platforms/kia_soul/firmware/throttle/tests/CMakeLists.txt
+++ b/platforms/kia_soul/firmware/throttle/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(kia-soul-throttle-tests)
+project(kia-soul-throttle-unit-tests)
 
 add_library(
     kia-soul-throttle
@@ -27,18 +27,18 @@ target_include_directories(
     ${CMAKE_SOURCE_DIR}/common/testing/mocks)
 
 add_executable(
-    kia-soul-throttle-test
+    kia-soul-throttle-unit-test
     features/step_definitions/test.cpp)
 
 target_link_libraries(
-    kia-soul-throttle-test
+    kia-soul-throttle-unit-test
     PRIVATE
     kia-soul-throttle
     ${CMAKE_SOURCE_DIR}/common/testing/framework/cucumber-cpp/lib/libcucumber-cpp.a
     ${CMAKE_SOURCE_DIR}/common/testing/framework/cgreen/lib/libcgreen.so)
 
 target_include_directories(
-    kia-soul-throttle-test
+    kia-soul-throttle-unit-test
     PRIVATE
     ../include
     ${CMAKE_SOURCE_DIR}/common/include
@@ -48,8 +48,14 @@ target_include_directories(
     ${CMAKE_SOURCE_DIR}/common/testing/framework/cgreen/include)
 
 add_custom_target(
-    run-throttle-tests
+    run-kia-soul-throttle-unit-tests
     DEPENDS
-    kia-soul-throttle-test
+    kia-soul-throttle-unit-test
     COMMAND
-    kia-soul-throttle-test --port=3902 >/dev/null & cucumber _2.0.0_ ${CMAKE_CURRENT_SOURCE_DIR}/features )
+    kia-soul-throttle-unit-test --port=3902 >/dev/null & cucumber _2.0.0_ ${CMAKE_CURRENT_SOURCE_DIR}/features )
+
+add_custom_target(
+    run-kia-soul-throttle-property-tests
+    COMMAND
+    cargo test -- --test-threads=1
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/property)


### PR DESCRIPTION
Prior to this commit, it wasn't possible to run the property-based tests
using CMake, which painfully required going to each tests directory and
building them manually. This commit adds targets for building all tests
(unit and property), unit only, property only, individually, or
platform-specific (e.g., all Kia Soul unit tests).