### PR TITLE
Check for sensor faults periodically

### DIFF
--- a/platforms/common/include/brake_can_protocol.h
+++ b/platforms/common/include/brake_can_protocol.h
@@ -121,19 +121,24 @@ typedef struct
                            * Value zero means controls are provided autonomously (no override).
                            * Value one means controls are provided by the driver. */
 
-    uint8_t reserved_5 : 1; /*!< Reserved. */
+    uint8_t fault_invalid_sensor_value : 1; /*!< Invalid sensor value indicator.
+                                             * Value zero means the values read
+                                             * from the sensors are valid.
+                                             *
+                                             * Value one means the values read
+                                             * from the sensors are invalid. */
 
-    uint8_t reserved_6 : 1; /*!< Reserved. */
+    uint8_t reserved_5 : 1; /*!< Reserved. */
 
     uint8_t fault_obd_timeout : 1; /*!< OBD timeout indicator.
                                    * Value zero means no timeout occurred.
                                    * Value one means timeout occurred. */
 
-    uint8_t reserved_7 : 1; /*!< Reserved */
+    uint8_t reserved_6 : 1; /*!< Reserved */
+
+    uint8_t reserved_7 : 1; /*!< Reserved. */
 
     uint8_t reserved_8 : 1; /*!< Reserved. */
-
-    uint8_t reserved_9 : 1; /*!< Reserved. */
 } oscc_report_brake_data_s;
 
 

--- a/platforms/common/include/steering_can_protocol.h
+++ b/platforms/common/include/steering_can_protocol.h
@@ -124,19 +124,24 @@ typedef struct
                            * Value zero means controls are provided autonomously (no override).
                            * Value one means controls are provided by the driver. */
 
-    uint8_t reserved_1 : 1; /*!< Reserved. */
+    uint8_t fault_invalid_sensor_value : 1; /*!< Invalid sensor value indicator.
+                                             * Value zero means the values read
+                                             * from the sensors are valid.
+                                             *
+                                             * Value one means the values read
+                                             * from the sensors are invalid. */
 
-    uint8_t reserved_2 : 1; /*!< Reserved. */
+    uint8_t reserved_1 : 1; /*!< Reserved. */
 
     uint8_t fault_obd_timeout : 1; /*!< OBD timeout indicator.
                                    * Value zero means no timeout occurred.
                                    * Value one means timeout occurred. */
 
-    uint8_t reserved_3 : 1; /*!< Reserved */
+    uint8_t reserved_2 : 1; /*!< Reserved */
+
+    uint8_t reserved_3 : 1; /*!< Reserved. */
 
     uint8_t reserved_4 : 1; /*!< Reserved. */
-
-    uint8_t reserved_5 : 1; /*!< Reserved. */
 } oscc_report_steering_data_s;
 
 

--- a/platforms/common/include/throttle_can_protocol.h
+++ b/platforms/common/include/throttle_can_protocol.h
@@ -119,6 +119,13 @@ typedef struct
                            * Value zero means controls are provided autonomously (no override).
                            * Value one means controls are provided by the driver. */
 
+    uint8_t fault_invalid_sensor_value : 1; /*!< Invalid sensor value indicator.
+                                             * Value zero means the values read
+                                             * from the sensors are valid.
+                                             *
+                                             * Value one means the values read
+                                             * from the sensors are invalid. */
+
     uint8_t reserved_2 : 1; /*!< Reserved. */
 
     uint8_t reserved_3 : 1; /*!< Reserved. */
@@ -128,8 +135,6 @@ typedef struct
     uint8_t reserved_5 : 1; /*!< Reserved. */
 
     uint8_t reserved_6 : 1; /*!< Reserved. */
-
-    uint8_t reserved_7 : 1; /*!< Reserved. */
 } oscc_report_throttle_data_s;
 
 

--- a/platforms/kia_soul/firmware/brake/include/brake_control.h
+++ b/platforms/kia_soul/firmware/brake/include/brake_control.h
@@ -49,6 +49,19 @@
 #define BRAKE_PRESSURE_SENSOR_EXPONENTIAL_FILTER_ALPHA ( 0.05 )
 
 /*
+ * @brief Amount of time between sensor checks. [milliseconds]
+ *
+ */
+#define SENSOR_VALIDITY_CHECK_INTERVAL_IN_MSEC ( 250 )
+
+/*
+ * @brief Number of consecutive faults that can occur when reading the
+ *        sensors before control is disabled.
+ *
+ */
+#define SENSOR_VALIDITY_CHECK_FAULT_COUNT ( 4 )
+
+/*
  * @brief Proportional gain of the PID controller.
  *
  */
@@ -154,6 +167,9 @@ typedef struct
     bool operator_override; /* Flag indicating whether brake pedal was
                                manually pressed by operator. */
 
+    bool invalid_sensor_value; /* Flag indicating a value read from one of the
+                                  sensors is invalid. */
+
     bool obd_timeout; /* Flag indicating whether an OBD timeout has occurred. */
 
     float current_sensor_brake_pressure; /* Current brake pressure as read
@@ -235,6 +251,20 @@ void disable_control( void );
 //
 // ****************************************************************************
 void check_for_operator_override( void );
+
+
+// ****************************************************************************
+// Function:    check_for_sensor_faults
+//
+// Purpose:     Checks to see if valid values are being read from the sensors.
+//
+// Returns:     void
+//
+// Parameters:  void
+//
+// ****************************************************************************
+void check_for_sensor_faults( void );
+
 
 
 // ****************************************************************************

--- a/platforms/kia_soul/firmware/brake/include/globals.h
+++ b/platforms/kia_soul/firmware/brake/include/globals.h
@@ -128,6 +128,7 @@
 EXTERN uint32_t g_brake_command_last_rx_timestamp;
 EXTERN uint32_t g_brake_report_last_tx_timestamp;
 EXTERN uint32_t g_chassis_state_1_report_last_rx_timestamp;
+EXTERN uint32_t g_sensor_validity_last_check_timestamp;
 
 EXTERN kia_soul_brake_control_state_s g_brake_control_state;
 

--- a/platforms/kia_soul/firmware/brake/src/communications.cpp
+++ b/platforms/kia_soul/firmware/brake/src/communications.cpp
@@ -75,6 +75,7 @@ static void publish_brake_report( void )
     brake_report.data.pedal_command = (uint16_t) g_brake_control_state.commanded_pedal_position;
     brake_report.data.pedal_output = (uint16_t) g_brake_control_state.current_sensor_brake_pressure;
     brake_report.data.fault_obd_timeout = (uint8_t) g_brake_control_state.obd_timeout;
+    brake_report.data.fault_invalid_sensor_value = (uint8_t) g_brake_control_state.invalid_sensor_value;
 
     g_control_can.sendMsgBuf(
         brake_report.id,

--- a/platforms/kia_soul/firmware/brake/src/main.cpp
+++ b/platforms/kia_soul/firmware/brake/src/main.cpp
@@ -38,6 +38,8 @@ int main( void )
 
         check_for_timeouts( );
 
+        check_for_sensor_faults( );
+
         check_for_operator_override( );
 
         publish_reports( );

--- a/platforms/kia_soul/firmware/brake/tests/features/checking_sensor_validity.feature
+++ b/platforms/kia_soul/firmware/brake/tests/features/checking_sensor_validity.feature
@@ -1,0 +1,21 @@
+# language: en
+
+Feature: Checking sensor validity
+
+  Invalid values read from sensors should cause control to be disabled.
+
+
+  Scenario: A sensor becomes temporarily disconnected
+    Given brake control is enabled
+
+    When a sensor becomes temporarily disconnected
+
+    Then control should remain enabled
+
+
+  Scenario: A sensor becomes permanently disconnected
+    Given brake control is enabled
+
+    When a sensor becomes permanently disconnected
+
+    Then control should be disabled

--- a/platforms/kia_soul/firmware/brake/tests/features/step_definitions/checking_sensor_validity.cpp
+++ b/platforms/kia_soul/firmware/brake/tests/features/step_definitions/checking_sensor_validity.cpp
@@ -1,0 +1,40 @@
+WHEN("^a sensor becomes temporarily disconnected$")
+{
+    // first check - error value - one fault
+    g_mock_arduino_analog_read_return = 0;
+    g_mock_arduino_millis_return = SENSOR_VALIDITY_CHECK_INTERVAL_IN_MSEC;
+    check_for_sensor_faults();
+
+    // second check - error value - two faults
+    g_mock_arduino_analog_read_return = 0;
+    g_mock_arduino_millis_return += SENSOR_VALIDITY_CHECK_INTERVAL_IN_MSEC;
+    check_for_sensor_faults();
+
+    // third check - valid value - faults reset
+    g_mock_arduino_analog_read_return = 500;
+    g_mock_arduino_millis_return += SENSOR_VALIDITY_CHECK_INTERVAL_IN_MSEC;
+    check_for_sensor_faults();
+}
+
+
+WHEN("^a sensor becomes permanently disconnected$")
+{
+    g_mock_arduino_analog_read_return = 0;
+    g_mock_arduino_millis_return = SENSOR_VALIDITY_CHECK_INTERVAL_IN_MSEC;
+
+    // must call function enough times to exceed the fault limit
+    for( int i = 0; i < SENSOR_VALIDITY_CHECK_FAULT_COUNT; ++i )
+    {
+        // continue timing out
+        g_mock_arduino_millis_return += SENSOR_VALIDITY_CHECK_INTERVAL_IN_MSEC;
+
+        check_for_sensor_faults();
+    }
+}
+
+THEN("^control should remain enabled")
+{
+    assert_that(
+        g_brake_control_state.enabled,
+        is_equal_to(1));
+}

--- a/platforms/kia_soul/firmware/brake/tests/features/step_definitions/test.cpp
+++ b/platforms/kia_soul/firmware/brake/tests/features/step_definitions/test.cpp
@@ -1,5 +1,6 @@
 // include source files to prevent step files from conflicting with each other
 #include "common.cpp"
+#include "checking_sensor_validity.cpp"
 #include "receiving_commands.cpp"
 #include "receiving_reports.cpp"
 #include "sending_reports.cpp"

--- a/platforms/kia_soul/firmware/steering/include/globals.h
+++ b/platforms/kia_soul/firmware/steering/include/globals.h
@@ -89,6 +89,7 @@
 EXTERN uint32_t g_steering_command_last_rx_timestamp;
 EXTERN uint32_t g_steering_report_last_tx_timestamp;
 EXTERN uint32_t g_chassis_state_1_report_last_rx_timestamp;
+EXTERN uint32_t g_sensor_validity_last_check_timestamp;
 EXTERN uint32_t g_last_control_loop_timestamp;
 
 EXTERN kia_soul_steering_control_state_s g_steering_control_state;

--- a/platforms/kia_soul/firmware/steering/include/steering_control.h
+++ b/platforms/kia_soul/firmware/steering/include/steering_control.h
@@ -66,6 +66,19 @@
 #define OVERRIDE_WHEEL_THRESHOLD_IN_DEGREES_PER_USEC ( 3000 )
 
 /*
+ * @brief Amount of time between sensor checks. [milliseconds]
+ *
+ */
+#define SENSOR_VALIDITY_CHECK_INTERVAL_IN_MSEC ( 250 )
+
+/*
+ * @brief Number of consecutive faults that can occur when reading the
+ *        torque sensor before control is disabled.
+ *
+ */
+#define SENSOR_VALIDITY_CHECK_FAULT_COUNT ( 4 )
+
+/*
  * @brief Alpha term for the exponential filter used to smooth the sensor input.
  *
  */
@@ -135,6 +148,9 @@ typedef struct
     bool operator_override; /* Flag indicating whether steering wheel was
                                manually turned by operator. */
 
+    bool invalid_sensor_value; /* Flag indicating a value read from one of the
+                                  sensors is invalid. */
+
     bool obd_timeout; /* Flag indicating whether an OBD timeout has occurred. */
 
     float current_steering_wheel_angle; /* Current steering angle as reported
@@ -162,6 +178,19 @@ typedef struct
 //
 // ****************************************************************************
 void check_for_operator_override( void );
+
+
+// ****************************************************************************
+// Function:    check_for_sensor_faults
+//
+// Purpose:     Checks to see if valid values are being read from the sensors.
+//
+// Returns:     void
+//
+// Parameters:  void
+//
+// ****************************************************************************
+void check_for_sensor_faults( void );
 
 
 // ****************************************************************************

--- a/platforms/kia_soul/firmware/steering/src/communications.cpp
+++ b/platforms/kia_soul/firmware/steering/src/communications.cpp
@@ -75,6 +75,7 @@ static void publish_steering_report( void )
     steering_report.data.commanded_steering_wheel_angle = (int16_t) g_steering_control_state.commanded_steering_wheel_angle;
     steering_report.data.fault_obd_timeout = (uint8_t) g_steering_control_state.obd_timeout;
     steering_report.data.spoofed_torque_output = (int8_t) g_spoofed_torque_output_sum;
+    steering_report.data.fault_invalid_sensor_value = (uint8_t) g_steering_control_state.invalid_sensor_value;
 
     g_control_can.sendMsgBuf(
         steering_report.id,

--- a/platforms/kia_soul/firmware/steering/src/main.cpp
+++ b/platforms/kia_soul/firmware/steering/src/main.cpp
@@ -37,6 +37,8 @@ int main( void )
 
         check_for_timeouts( );
 
+        check_for_sensor_faults( );
+
         uint32_t time_since_last_control_loop_in_msec = get_time_delta(
             g_last_control_loop_timestamp,
             GET_TIMESTAMP_MS());

--- a/platforms/kia_soul/firmware/steering/tests/features/checking_sensor_validity.feature
+++ b/platforms/kia_soul/firmware/steering/tests/features/checking_sensor_validity.feature
@@ -1,0 +1,21 @@
+# language: en
+
+Feature: Checking sensor validity
+
+  Invalid values read from sensors should cause control to be disabled.
+
+
+  Scenario: A sensor becomes temporarily disconnected
+    Given steering control is enabled
+
+    When a sensor becomes temporarily disconnected
+
+    Then control should remain enabled
+
+
+  Scenario: A sensor becomes permanently disconnected
+    Given steering control is enabled
+
+    When a sensor becomes permanently disconnected
+
+    Then control should be disabled

--- a/platforms/kia_soul/firmware/steering/tests/features/step_definitions/checking_sensor_validity.cpp
+++ b/platforms/kia_soul/firmware/steering/tests/features/step_definitions/checking_sensor_validity.cpp
@@ -1,0 +1,40 @@
+WHEN("^a sensor becomes temporarily disconnected$")
+{
+    // first check - error value - one fault
+    g_mock_arduino_analog_read_return = 0;
+    g_mock_arduino_millis_return = SENSOR_VALIDITY_CHECK_INTERVAL_IN_MSEC;
+    check_for_sensor_faults();
+
+    // second check - error value - two faults
+    g_mock_arduino_analog_read_return = 0;
+    g_mock_arduino_millis_return += SENSOR_VALIDITY_CHECK_INTERVAL_IN_MSEC;
+    check_for_sensor_faults();
+
+    // third check - valiud value - faults reset
+    g_mock_arduino_analog_read_return = 500;
+    g_mock_arduino_millis_return += SENSOR_VALIDITY_CHECK_INTERVAL_IN_MSEC;
+    check_for_sensor_faults();
+}
+
+
+WHEN("^a sensor becomes permanently disconnected$")
+{
+    g_mock_arduino_analog_read_return = 0;
+    g_mock_arduino_millis_return = SENSOR_VALIDITY_CHECK_INTERVAL_IN_MSEC;
+
+    // must call function enough times to exceed the fault limit
+    for( int i = 0; i < SENSOR_VALIDITY_CHECK_FAULT_COUNT; ++i )
+    {
+        // continue timing out
+        g_mock_arduino_millis_return += SENSOR_VALIDITY_CHECK_INTERVAL_IN_MSEC;
+
+        check_for_sensor_faults();
+    }
+}
+
+THEN("^control should remain enabled")
+{
+    assert_that(
+        g_steering_control_state.enabled,
+        is_equal_to(1));
+}

--- a/platforms/kia_soul/firmware/steering/tests/features/step_definitions/checking_sensor_validity.cpp
+++ b/platforms/kia_soul/firmware/steering/tests/features/step_definitions/checking_sensor_validity.cpp
@@ -10,7 +10,7 @@ WHEN("^a sensor becomes temporarily disconnected$")
     g_mock_arduino_millis_return += SENSOR_VALIDITY_CHECK_INTERVAL_IN_MSEC;
     check_for_sensor_faults();
 
-    // third check - valiud value - faults reset
+    // third check - valid value - faults reset
     g_mock_arduino_analog_read_return = 500;
     g_mock_arduino_millis_return += SENSOR_VALIDITY_CHECK_INTERVAL_IN_MSEC;
     check_for_sensor_faults();

--- a/platforms/kia_soul/firmware/steering/tests/features/step_definitions/test.cpp
+++ b/platforms/kia_soul/firmware/steering/tests/features/step_definitions/test.cpp
@@ -1,5 +1,6 @@
 // include source files to prevent step files from conflicting with each other
 #include "common.cpp"
+#include "checking_sensor_validity.cpp"
 #include "receiving_commands.cpp"
 #include "receiving_reports.cpp"
 #include "sending_reports.cpp"

--- a/platforms/kia_soul/firmware/throttle/include/globals.h
+++ b/platforms/kia_soul/firmware/throttle/include/globals.h
@@ -73,6 +73,7 @@
 
 EXTERN uint32_t g_throttle_command_last_rx_timestamp;
 EXTERN uint32_t g_throttle_report_last_tx_timestamp;
+EXTERN uint32_t g_accelerator_position_sensor_last_check_timestamp;
 
 EXTERN kia_soul_throttle_control_state_s g_throttle_control_state;
 EXTERN uint16_t g_accelerator_spoof_output_sum;

--- a/platforms/kia_soul/firmware/throttle/include/globals.h
+++ b/platforms/kia_soul/firmware/throttle/include/globals.h
@@ -73,7 +73,7 @@
 
 EXTERN uint32_t g_throttle_command_last_rx_timestamp;
 EXTERN uint32_t g_throttle_report_last_tx_timestamp;
-EXTERN uint32_t g_accelerator_position_sensor_last_check_timestamp;
+EXTERN uint32_t g_sensor_validity_last_check_timestamp;
 
 EXTERN kia_soul_throttle_control_state_s g_throttle_control_state;
 EXTERN uint16_t g_accelerator_spoof_output_sum;

--- a/platforms/kia_soul/firmware/throttle/include/throttle_control.h
+++ b/platforms/kia_soul/firmware/throttle/include/throttle_control.h
@@ -80,18 +80,17 @@
 #define ACCELERATOR_OVERRIDE_THRESHOLD ( 750.0 )
 
 /*
- * @brief Amount of time between accelerator position sensor checks.
- *        [milliseconds]
+ * @brief Amount of time between sensor checks. [milliseconds]
  *
  */
-#define ACCELERATOR_POSITION_SENSOR_VALIDITY_CHECK_INTERVAL_IN_MSEC ( 250 )
+#define SENSOR_VALIDITY_CHECK_INTERVAL_IN_MSEC ( 250 )
 
 /*
  * @brief Number of consecutive faults that can occur when reading the
- *        accelerator position sensor before control is disabled.
+ *        sensors before control is disabled.
  *
  */
-#define ACCELERATOR_POSITION_SENSOR_VALIDITY_CHECK_FAULT_COUNT ( 4 )
+#define SENSOR_VALIDITY_CHECK_FAULT_COUNT ( 4 )
 
 /*
  * @brief Alpha term for the exponential filter used to smooth the sensor input.
@@ -150,17 +149,16 @@ void check_for_operator_override( void );
 
 
 // ****************************************************************************
-// Function:    check_for_sensor_problems
+// Function:    check_for_sensor_faults
 //
-// Purpose:     Checks to see if the values read from the accelerator position
-//              sensor are valid.
+// Purpose:     Checks to see if valid values are being read from the sensors.
 //
 // Returns:     void
 //
 // Parameters:  void
 //
 // ****************************************************************************
-void check_for_sensor_problems( void );
+void check_for_sensor_faults( void );
 
 
 // ****************************************************************************

--- a/platforms/kia_soul/firmware/throttle/include/throttle_control.h
+++ b/platforms/kia_soul/firmware/throttle/include/throttle_control.h
@@ -126,8 +126,8 @@ typedef struct
     bool operator_override; /* Flag indicating whether accelerator was manually
                                pressed by operator. */
 
-    bool invalid_sensor_value; /* Flag indicating the value read from the
-                                  accelerator position sensor is invalid. */
+    bool invalid_sensor_value; /* Flag indicating a value read from one of the
+                                  sensors is invalid. */
 
     uint16_t commanded_accelerator_position; /* Position of accelerator commanded
                                                 by the controller. */

--- a/platforms/kia_soul/firmware/throttle/include/throttle_control.h
+++ b/platforms/kia_soul/firmware/throttle/include/throttle_control.h
@@ -79,6 +79,19 @@
 
 #define ACCELERATOR_OVERRIDE_THRESHOLD ( 750.0 )
 
+/*
+ * @brief Amount of time between accelerator position sensor checks.
+ *        [milliseconds]
+ *
+ */
+#define ACCELERATOR_POSITION_SENSOR_VALIDITY_CHECK_INTERVAL_IN_MSEC ( 250 )
+
+/*
+ * @brief Number of consecutive faults that can occur when reading the
+ *        accelerator position sensor before control is disabled.
+ *
+ */
+#define ACCELERATOR_POSITION_SENSOR_VALIDITY_CHECK_FAULT_COUNT ( 4 )
 
 /*
  * @brief Alpha term for the exponential filter used to smooth the sensor input.
@@ -114,6 +127,9 @@ typedef struct
     bool operator_override; /* Flag indicating whether accelerator was manually
                                pressed by operator. */
 
+    bool invalid_sensor_value; /* Flag indicating the value read from the
+                                  accelerator position sensor is invalid. */
+
     uint16_t commanded_accelerator_position; /* Position of accelerator commanded
                                                 by the controller. */
 } kia_soul_throttle_control_state_s;
@@ -131,6 +147,20 @@ typedef struct
 //
 // ****************************************************************************
 void check_for_operator_override( void );
+
+
+// ****************************************************************************
+// Function:    check_for_sensor_problems
+//
+// Purpose:     Checks to see if the values read from the accelerator position
+//              sensor are valid.
+//
+// Returns:     void
+//
+// Parameters:  void
+//
+// ****************************************************************************
+void check_for_sensor_problems( void );
 
 
 // ****************************************************************************

--- a/platforms/kia_soul/firmware/throttle/src/communications.cpp
+++ b/platforms/kia_soul/firmware/throttle/src/communications.cpp
@@ -82,6 +82,8 @@ static void publish_throttle_report( void )
     throttle_report.data.commanded_accelerator_position =
         g_throttle_control_state.commanded_accelerator_position;
     throttle_report.data.spoofed_accelerator_output = g_accelerator_spoof_output_sum;
+    throttle_report.data.fault_invalid_sensor_value =
+        g_throttle_control_state.invalid_sensor_value;
 
     g_control_can.sendMsgBuf(
             throttle_report.id,

--- a/platforms/kia_soul/firmware/throttle/src/init.cpp
+++ b/platforms/kia_soul/firmware/throttle/src/init.cpp
@@ -23,6 +23,7 @@ void init_globals( void )
     // update timestamps so we don't set timeout warnings on start up
     g_throttle_command_last_rx_timestamp = GET_TIMESTAMP_MS( );
     g_throttle_report_last_tx_timestamp = GET_TIMESTAMP_MS( );
+    g_accelerator_position_sensor_last_check_timestamp = GET_TIMESTAMP_MS();
 }
 
 

--- a/platforms/kia_soul/firmware/throttle/src/init.cpp
+++ b/platforms/kia_soul/firmware/throttle/src/init.cpp
@@ -23,7 +23,7 @@ void init_globals( void )
     // update timestamps so we don't set timeout warnings on start up
     g_throttle_command_last_rx_timestamp = GET_TIMESTAMP_MS( );
     g_throttle_report_last_tx_timestamp = GET_TIMESTAMP_MS( );
-    g_accelerator_position_sensor_last_check_timestamp = GET_TIMESTAMP_MS();
+    g_sensor_validity_last_check_timestamp = GET_TIMESTAMP_MS();
 }
 
 

--- a/platforms/kia_soul/firmware/throttle/src/main.cpp
+++ b/platforms/kia_soul/firmware/throttle/src/main.cpp
@@ -35,7 +35,7 @@ int main( void )
 
         check_for_controller_command_timeout( );
 
-        check_for_sensor_problems( );
+        check_for_sensor_faults( );
 
         check_for_operator_override( );
 

--- a/platforms/kia_soul/firmware/throttle/src/main.cpp
+++ b/platforms/kia_soul/firmware/throttle/src/main.cpp
@@ -35,6 +35,8 @@ int main( void )
 
         check_for_controller_command_timeout( );
 
+        check_for_sensor_problems( );
+
         check_for_operator_override( );
 
         publish_reports( );

--- a/platforms/kia_soul/firmware/throttle/src/throttle_control.cpp
+++ b/platforms/kia_soul/firmware/throttle/src/throttle_control.cpp
@@ -49,7 +49,7 @@ void check_for_operator_override( void )
 }
 
 
-void check_for_sensor_problems( void )
+void check_for_sensor_faults( void )
 {
     if ( (g_throttle_control_state.enabled == true)
         || (g_throttle_control_state.invalid_sensor_value == true) )
@@ -59,7 +59,7 @@ void check_for_sensor_problems( void )
         bool timeout = is_timeout(
             g_accelerator_position_sensor_last_check_timestamp,
             current_time,
-            ACCELERATOR_POSITION_SENSOR_VALIDITY_CHECK_INTERVAL_IN_MSEC );
+            SENSOR_VALIDITY_CHECK_INTERVAL_IN_MSEC );
 
         static int fault_count = 0;
 
@@ -76,7 +76,7 @@ void check_for_sensor_problems( void )
             {
                 ++fault_count;
 
-                if( fault_count >= ACCELERATOR_POSITION_SENSOR_VALIDITY_CHECK_FAULT_COUNT )
+                if( fault_count >= SENSOR_VALIDITY_CHECK_FAULT_COUNT )
                 {
                     disable_control( );
 

--- a/platforms/kia_soul/firmware/throttle/src/throttle_control.cpp
+++ b/platforms/kia_soul/firmware/throttle/src/throttle_control.cpp
@@ -57,7 +57,7 @@ void check_for_sensor_faults( void )
         uint32_t current_time = GET_TIMESTAMP_MS();
 
         bool timeout = is_timeout(
-            g_accelerator_position_sensor_last_check_timestamp,
+            g_sensor_validity_last_check_timestamp,
             current_time,
             SENSOR_VALIDITY_CHECK_INTERVAL_IN_MSEC );
 
@@ -65,7 +65,7 @@ void check_for_sensor_faults( void )
 
         if( timeout == true )
         {
-            g_accelerator_position_sensor_last_check_timestamp = current_time;
+            g_sensor_validity_last_check_timestamp = current_time;
 
             int sensor_high = analogRead( PIN_ACCELERATOR_POSITION_SENSOR_HIGH );
             int sensor_low = analogRead( PIN_ACCELERATOR_POSITION_SENSOR_LOW );

--- a/platforms/kia_soul/firmware/throttle/tests/features/checking_sensor_validity.feature
+++ b/platforms/kia_soul/firmware/throttle/tests/features/checking_sensor_validity.feature
@@ -5,17 +5,17 @@ Feature: Checking sensor validity
   Invalid values read from sensors should cause control to be disabled.
 
 
-  Scenario: Accelerator position sensor becomes temporarily disconnected
+  Scenario: A sensor becomes temporarily disconnected
     Given throttle control is enabled
 
-    When the accelerator position sensor becomes temporarily disconnected
+    When a sensor becomes temporarily disconnected
 
     Then control should remain enabled
 
 
-  Scenario: Accelerator position sensor becomes permanently disconnected
+  Scenario: A sensor becomes permanently disconnected
     Given throttle control is enabled
 
-    When the accelerator position sensor becomes permanently disconnected
+    When a sensor becomes permanently disconnected
 
     Then control should be disabled

--- a/platforms/kia_soul/firmware/throttle/tests/features/checking_sensor_validity.feature
+++ b/platforms/kia_soul/firmware/throttle/tests/features/checking_sensor_validity.feature
@@ -1,0 +1,21 @@
+# language: en
+
+Feature: Checking sensor validity
+
+  Invalid values read from sensors should cause control to be disabled.
+
+
+  Scenario: Accelerator position sensor becomes temporarily disconnected
+    Given throttle control is enabled
+
+    When the accelerator position sensor becomes temporarily disconnected
+
+    Then control should remain enabled
+
+
+  Scenario: Accelerator position sensor becomes permanently disconnected
+    Given throttle control is enabled
+
+    When the accelerator position sensor becomes permanently disconnected
+
+    Then control should be disabled

--- a/platforms/kia_soul/firmware/throttle/tests/features/step_definitions/checking_sensor_validity.cpp
+++ b/platforms/kia_soul/firmware/throttle/tests/features/step_definitions/checking_sensor_validity.cpp
@@ -1,0 +1,40 @@
+WHEN("^the accelerator position sensor becomes temporarily disconnected$")
+{
+    // first check - error value - one fault
+    g_mock_arduino_analog_read_return = 0;
+    g_mock_arduino_millis_return = ACCELERATOR_POSITION_SENSOR_VALIDITY_CHECK_INTERVAL_IN_MSEC;
+    check_for_sensor_problems();
+
+    // second check - error value - two faults
+    g_mock_arduino_analog_read_return = 0;
+    g_mock_arduino_millis_return += ACCELERATOR_POSITION_SENSOR_VALIDITY_CHECK_INTERVAL_IN_MSEC;
+    check_for_sensor_problems();
+
+    // third check - valiud value - faults reset
+    g_mock_arduino_analog_read_return = 500;
+    g_mock_arduino_millis_return += ACCELERATOR_POSITION_SENSOR_VALIDITY_CHECK_INTERVAL_IN_MSEC;
+    check_for_sensor_problems();
+}
+
+
+WHEN("^the accelerator position sensor becomes permanently disconnected$")
+{
+    g_mock_arduino_analog_read_return = 0;
+    g_mock_arduino_millis_return = ACCELERATOR_POSITION_SENSOR_VALIDITY_CHECK_INTERVAL_IN_MSEC;
+
+    // must call function enough times to exceed the fault limit
+    for( int i = 0; i < ACCELERATOR_POSITION_SENSOR_VALIDITY_CHECK_FAULT_COUNT; ++i )
+    {
+        // continue timing out
+        g_mock_arduino_millis_return += ACCELERATOR_POSITION_SENSOR_VALIDITY_CHECK_INTERVAL_IN_MSEC;
+
+        check_for_sensor_problems();
+    }
+}
+
+THEN("^control should remain enabled")
+{
+    assert_that(
+        g_throttle_control_state.enabled,
+        is_equal_to(1));
+}

--- a/platforms/kia_soul/firmware/throttle/tests/features/step_definitions/checking_sensor_validity.cpp
+++ b/platforms/kia_soul/firmware/throttle/tests/features/step_definitions/checking_sensor_validity.cpp
@@ -1,34 +1,34 @@
-WHEN("^the accelerator position sensor becomes temporarily disconnected$")
+WHEN("^a sensor becomes temporarily disconnected$")
 {
     // first check - error value - one fault
     g_mock_arduino_analog_read_return = 0;
-    g_mock_arduino_millis_return = ACCELERATOR_POSITION_SENSOR_VALIDITY_CHECK_INTERVAL_IN_MSEC;
-    check_for_sensor_problems();
+    g_mock_arduino_millis_return = SENSOR_VALIDITY_CHECK_INTERVAL_IN_MSEC;
+    check_for_sensor_faults();
 
     // second check - error value - two faults
     g_mock_arduino_analog_read_return = 0;
-    g_mock_arduino_millis_return += ACCELERATOR_POSITION_SENSOR_VALIDITY_CHECK_INTERVAL_IN_MSEC;
-    check_for_sensor_problems();
+    g_mock_arduino_millis_return += SENSOR_VALIDITY_CHECK_INTERVAL_IN_MSEC;
+    check_for_sensor_faults();
 
     // third check - valiud value - faults reset
     g_mock_arduino_analog_read_return = 500;
-    g_mock_arduino_millis_return += ACCELERATOR_POSITION_SENSOR_VALIDITY_CHECK_INTERVAL_IN_MSEC;
-    check_for_sensor_problems();
+    g_mock_arduino_millis_return += SENSOR_VALIDITY_CHECK_INTERVAL_IN_MSEC;
+    check_for_sensor_faults();
 }
 
 
-WHEN("^the accelerator position sensor becomes permanently disconnected$")
+WHEN("^a sensor becomes permanently disconnected$")
 {
     g_mock_arduino_analog_read_return = 0;
-    g_mock_arduino_millis_return = ACCELERATOR_POSITION_SENSOR_VALIDITY_CHECK_INTERVAL_IN_MSEC;
+    g_mock_arduino_millis_return = SENSOR_VALIDITY_CHECK_INTERVAL_IN_MSEC;
 
     // must call function enough times to exceed the fault limit
-    for( int i = 0; i < ACCELERATOR_POSITION_SENSOR_VALIDITY_CHECK_FAULT_COUNT; ++i )
+    for( int i = 0; i < SENSOR_VALIDITY_CHECK_FAULT_COUNT; ++i )
     {
         // continue timing out
-        g_mock_arduino_millis_return += ACCELERATOR_POSITION_SENSOR_VALIDITY_CHECK_INTERVAL_IN_MSEC;
+        g_mock_arduino_millis_return += SENSOR_VALIDITY_CHECK_INTERVAL_IN_MSEC;
 
-        check_for_sensor_problems();
+        check_for_sensor_faults();
     }
 }
 

--- a/platforms/kia_soul/firmware/throttle/tests/features/step_definitions/checking_sensor_validity.cpp
+++ b/platforms/kia_soul/firmware/throttle/tests/features/step_definitions/checking_sensor_validity.cpp
@@ -10,7 +10,7 @@ WHEN("^a sensor becomes temporarily disconnected$")
     g_mock_arduino_millis_return += SENSOR_VALIDITY_CHECK_INTERVAL_IN_MSEC;
     check_for_sensor_faults();
 
-    // third check - valiud value - faults reset
+    // third check - valid value - faults reset
     g_mock_arduino_analog_read_return = 500;
     g_mock_arduino_millis_return += SENSOR_VALIDITY_CHECK_INTERVAL_IN_MSEC;
     check_for_sensor_faults();

--- a/platforms/kia_soul/firmware/throttle/tests/features/step_definitions/test.cpp
+++ b/platforms/kia_soul/firmware/throttle/tests/features/step_definitions/test.cpp
@@ -1,5 +1,6 @@
 // include source files to prevent step files from conflicting with each other
 #include "common.cpp"
+#include "checking_sensor_validity.cpp"
 #include "receiving_commands.cpp"
 #include "sending_reports.cpp"
 #include "timeouts_and_overrides.cpp"

--- a/utils/joystick_commander/include/oscc_interface.h
+++ b/utils/joystick_commander/include/oscc_interface.h
@@ -20,6 +20,7 @@ typedef struct
     bool operator_override;
     bool obd_timeout_brake;
     bool obd_timeout_steering;
+    bool invalid_sensor_value_throttle;
 } oscc_status_s;
 
 

--- a/utils/joystick_commander/include/oscc_interface.h
+++ b/utils/joystick_commander/include/oscc_interface.h
@@ -20,6 +20,7 @@ typedef struct
     bool operator_override;
     bool obd_timeout_brake;
     bool obd_timeout_steering;
+    bool invalid_sensor_value_brake;
     bool invalid_sensor_value_throttle;
 } oscc_status_s;
 

--- a/utils/joystick_commander/include/oscc_interface.h
+++ b/utils/joystick_commander/include/oscc_interface.h
@@ -22,6 +22,7 @@ typedef struct
     bool obd_timeout_steering;
     bool invalid_sensor_value_brake;
     bool invalid_sensor_value_throttle;
+    bool invalid_sensor_value_steering;
 } oscc_status_s;
 
 

--- a/utils/joystick_commander/include/oscc_interface.h
+++ b/utils/joystick_commander/include/oscc_interface.h
@@ -21,8 +21,8 @@ typedef struct
     bool obd_timeout_brake;
     bool obd_timeout_steering;
     bool invalid_sensor_value_brake;
-    bool invalid_sensor_value_throttle;
     bool invalid_sensor_value_steering;
+    bool invalid_sensor_value_throttle;
 } oscc_status_s;
 
 

--- a/utils/joystick_commander/src/commander.c
+++ b/utils/joystick_commander/src/commander.c
@@ -759,6 +759,13 @@ int commander_high_frequency_update( )
         return_code = oscc_interface_disable_steering( );
     }
 
+    if ( status.invalid_sensor_value_brake == true )
+    {
+        printf( "Brake - Invalid Sensor Value Detected\n" );
+        return_code = oscc_interface_disable_steering( );
+
+    }
+
     if ( status.invalid_sensor_value_throttle == true )
     {
         printf( "Throttle - Invalid Sensor Value Detected\n" );

--- a/utils/joystick_commander/src/commander.c
+++ b/utils/joystick_commander/src/commander.c
@@ -763,20 +763,18 @@ int commander_high_frequency_update( )
     {
         printf( "Brake - Invalid Sensor Value Detected\n" );
         return_code = oscc_interface_disable_steering( );
-
-    }
-
-    if ( status.invalid_sensor_value_throttle == true )
-    {
-        printf( "Throttle - Invalid Sensor Value Detected\n" );
-        return_code = oscc_interface_disable_throttle( );
-
     }
 
     if ( status.invalid_sensor_value_steering == true )
     {
         printf( "Steering - Invalid Sensor Value Detected\n" );
         return_code = oscc_interface_disable_steering( );
+    }
+
+    if ( status.invalid_sensor_value_throttle == true )
+    {
+        printf( "Throttle - Invalid Sensor Value Detected\n" );
+        return_code = oscc_interface_disable_throttle( );
 
     }
 

--- a/utils/joystick_commander/src/commander.c
+++ b/utils/joystick_commander/src/commander.c
@@ -759,5 +759,12 @@ int commander_high_frequency_update( )
         return_code = oscc_interface_disable_steering( );
     }
 
+    if ( status.invalid_sensor_value_throttle == true )
+    {
+        printf( "Throttle - Invalid Sensor Value Detected\n" );
+        return_code = oscc_interface_disable_throttle( );
+
+    }
+
     return return_code;
 }

--- a/utils/joystick_commander/src/commander.c
+++ b/utils/joystick_commander/src/commander.c
@@ -773,5 +773,12 @@ int commander_high_frequency_update( )
 
     }
 
+    if ( status.invalid_sensor_value_steering == true )
+    {
+        printf( "Steering - Invalid Sensor Value Detected\n" );
+        return_code = oscc_interface_disable_steering( );
+
+    }
+
     return return_code;
 }

--- a/utils/joystick_commander/src/oscc_interface.c
+++ b/utils/joystick_commander/src/oscc_interface.c
@@ -239,7 +239,14 @@ static void oscc_interface_check_for_invalid_sensor_value(
     long can_id,
     unsigned char * buffer )
 {
-    if ( can_id == OSCC_REPORT_THROTTLE_CAN_ID )
+    if ( can_id == OSCC_REPORT_BRAKE_CAN_ID )
+    {
+        oscc_report_brake_data_s* brake_report_data =
+            ( oscc_report_brake_data_s* )buffer;
+
+        status->invalid_sensor_value_brake = (bool) brake_report_data->fault_invalid_sensor_value;
+    }
+    else if ( can_id == OSCC_REPORT_THROTTLE_CAN_ID )
     {
         oscc_report_throttle_data_s* throttle_report_data =
             ( oscc_report_throttle_data_s* )buffer;

--- a/utils/joystick_commander/src/oscc_interface.c
+++ b/utils/joystick_commander/src/oscc_interface.c
@@ -223,6 +223,31 @@ static void oscc_interface_check_for_obd_timeout(
     }
 }
 
+// **********************************************************
+// Function:    oscc_interface_check_for_invalid_sensor_value
+//
+// Purpose:     Checks report messages for invalid sensor value flag.
+//
+// Returns:     bool - invalid sensor value flag
+//
+// Parameters:  can_id - ID of CAN frame containing the report
+//              buffer - Buffer of CAN frame containing the report
+//
+// **********************************************************
+static void oscc_interface_check_for_invalid_sensor_value(
+    oscc_status_s * status,
+    long can_id,
+    unsigned char * buffer )
+{
+    if ( can_id == OSCC_REPORT_THROTTLE_CAN_ID )
+    {
+        oscc_report_throttle_data_s* throttle_report_data =
+            ( oscc_report_throttle_data_s* )buffer;
+
+        status->invalid_sensor_value_throttle = (bool) throttle_report_data->fault_invalid_sensor_value;
+    }
+}
+
 // *****************************************************
 // public definitions
 // *****************************************************
@@ -568,6 +593,8 @@ int oscc_interface_update_status( oscc_status_s * status )
             oscc_interface_check_for_operator_override( status, can_id, buffer );
 
             oscc_interface_check_for_obd_timeout( status, can_id, buffer );
+
+            oscc_interface_check_for_invalid_sensor_value( status, can_id, buffer );
         }
         else if( ( can_status == canERR_NOMSG ) || ( can_status == canERR_TIMEOUT ) )
         {

--- a/utils/joystick_commander/src/oscc_interface.c
+++ b/utils/joystick_commander/src/oscc_interface.c
@@ -253,6 +253,13 @@ static void oscc_interface_check_for_invalid_sensor_value(
 
         status->invalid_sensor_value_throttle = (bool) throttle_report_data->fault_invalid_sensor_value;
     }
+    else if ( can_id == OSCC_REPORT_STEERING_CAN_ID )
+    {
+        oscc_report_steering_data_s* steering_report_data =
+            ( oscc_report_steering_data_s* )buffer;
+
+        status->invalid_sensor_value_steering = (bool) steering_report_data->fault_invalid_sensor_value;
+    }
 }
 
 // *****************************************************

--- a/utils/joystick_commander/src/oscc_interface.c
+++ b/utils/joystick_commander/src/oscc_interface.c
@@ -246,19 +246,19 @@ static void oscc_interface_check_for_invalid_sensor_value(
 
         status->invalid_sensor_value_brake = (bool) brake_report_data->fault_invalid_sensor_value;
     }
-    else if ( can_id == OSCC_REPORT_THROTTLE_CAN_ID )
-    {
-        oscc_report_throttle_data_s* throttle_report_data =
-            ( oscc_report_throttle_data_s* )buffer;
-
-        status->invalid_sensor_value_throttle = (bool) throttle_report_data->fault_invalid_sensor_value;
-    }
     else if ( can_id == OSCC_REPORT_STEERING_CAN_ID )
     {
         oscc_report_steering_data_s* steering_report_data =
             ( oscc_report_steering_data_s* )buffer;
 
         status->invalid_sensor_value_steering = (bool) steering_report_data->fault_invalid_sensor_value;
+    }
+    else if ( can_id == OSCC_REPORT_THROTTLE_CAN_ID )
+    {
+        oscc_report_throttle_data_s* throttle_report_data =
+            ( oscc_report_throttle_data_s* )buffer;
+
+        status->invalid_sensor_value_throttle = (bool) throttle_report_data->fault_invalid_sensor_value;
     }
 }
 


### PR DESCRIPTION
The sensors used in the modules were not being checked for valid values so it was possible for a sensor wire to become disconnected while control continued to be enabled. This PR address that by doing a periodic check of the sensor values to see if any of them return a value of 0 indicating a
problem because the sensor pins are tied to ground and will be 0 if
they become disconnected (and should never be 0 otherwise).