### PR TITLE
Use additional brake sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,12 +144,13 @@ you can get it with the following command:
 sudo apt install screen
 ```
 
-You need to tell CMake what serial port the module you want to monitor is connected
-to (see [section on uploading](#uploading-the-firmware) for details on the default
+You need to enable debug mode with `-DDEBUG=ON` and tell CMake what serial port
+the module you want to monitor is connected to
+(see [section on uploading](#uploading-the-firmware) for details on the default
 ports for each module). The default baud rate is `115200` but you can change it:
 
 ```
-cmake .. -DBUILD_KIA_SOUL=ON -DSERIAL_PORT_THROTTLE=/dev/ttyACM0 -DSERIAL_BAUD_THROTTLE=19200
+cmake .. -DBUILD_KIA_SOUL=ON -DDEBUG=ON -DSERIAL_PORT_THROTTLE=/dev/ttyACM0 -DSERIAL_BAUD_THROTTLE=19200
 ```
 
 You can use a module's `monitor` target to automatically run `screen`, or a

--- a/platforms/common/include/brake_can_protocol.h
+++ b/platforms/common/include/brake_can_protocol.h
@@ -128,17 +128,23 @@ typedef struct
                                              * Value one means the values read
                                              * from the sensors are invalid. */
 
-    uint8_t reserved_5 : 1; /*!< Reserved. */
+    uint8_t fault_startup_pressure_check_error : 1; /*!< Actuator sensors report
+                                                     * values that do not match
+                                                     * the static values
+                                                     * expected with PCK1 and
+                                                     * PCK2 asserted. */
 
     uint8_t fault_obd_timeout : 1; /*!< OBD timeout indicator.
                                    * Value zero means no timeout occurred.
                                    * Value one means timeout occurred. */
 
-    uint8_t reserved_6 : 1; /*!< Reserved */
+    uint8_t fault_startup_pump_motor_check_error : 1; /*!< Pump motor check signal
+                                                       * (MTT) is not asserted
+                                                       * when pump is on. */
 
-    uint8_t reserved_7 : 1; /*!< Reserved. */
+    uint8_t reserved_5 : 1; /*!< Reserved. */
 
-    uint8_t reserved_8 : 1; /*!< Reserved. */
+    uint8_t reserved_6 : 1; /*!< Reserved. */
 } oscc_report_brake_data_s;
 
 

--- a/platforms/kia_soul/firmware/brake/include/brake_control.h
+++ b/platforms/kia_soul/firmware/brake/include/brake_control.h
@@ -49,6 +49,20 @@
 #define BRAKE_PRESSURE_SENSOR_EXPONENTIAL_FILTER_ALPHA ( 0.05 )
 
 /*
+ * @brief Minimum possible value expected to be read from the brake pressure
+ * sensors when the pressure check pins (PCK1/PCK2) are asserted.
+ *
+ */
+#define BRAKE_PRESSURE_SENSOR_CHECK_VALUE_MIN ( 665 )
+
+/*
+ * @brief Maximum possible value expected to be read from the brake pressure
+ * sensors when the pressure check pins (PCK1/PCK2) are asserted.
+ *
+ */
+#define BRAKE_PRESSURE_SENSOR_CHECK_VALUE_MAX ( 680 )
+
+/*
  * @brief Amount of time between sensor checks. [milliseconds]
  *
  */
@@ -171,6 +185,10 @@ typedef struct
                                   sensors is invalid. */
 
     bool obd_timeout; /* Flag indicating whether an OBD timeout has occurred. */
+
+    bool startup_pressure_check_error; /* Flag indicating a problem with the actuator. */
+
+    bool startup_pump_motor_check_error; /* Flag indicating a problem with the pump motor. */
 
     float current_sensor_brake_pressure; /* Current brake pressure as read
                                                from the brake pressure sensor. */

--- a/platforms/kia_soul/firmware/brake/include/globals.h
+++ b/platforms/kia_soul/firmware/brake/include/globals.h
@@ -50,6 +50,12 @@
 #define PIN_ACCUMULATOR_PUMP_MOTOR ( 49 )
 
 /*
+ * @brief Pin of the accumulator pump motor check (MTT) signal.
+ *
+ */
+#define PIN_ACCUMULATOR_PUMP_MOTOR_CHECK ( 8 )
+
+/*
  * @brief Pin of the master cylinder solenoid.
  *
  */
@@ -84,16 +90,28 @@
 #define PIN_RELEASE_SOLENOID_FRONT_RIGHT ( 8 )
 
 /*
- * @brief Pin of the front right pressure sensor.
+ * @brief Pin of the front left pressure sensor.
  *
  */
 #define PIN_PRESSURE_SENSOR_FRONT_LEFT ( 14 )
 
 /*
- * @brief Pin of the front left pressure sensor.
+ * @brief Pin of the front right pressure sensor.
  *
  */
 #define PIN_PRESSURE_SENSOR_FRONT_RIGHT ( 13 )
+
+/*
+ * @brief Pin of the wheel pressure check 1 (PCK1) signal.
+ *
+ */
+#define PIN_WHEEL_PRESSURE_CHECK_1 ( 13 )
+
+/*
+ * @brief Pin of the wheel pressure check 2 (PCK2) signal.
+ *
+ */
+#define PIN_WHEEL_PRESSURE_CHECK_2 ( 12 )
 
 /*
  * @brief Pin of the brake light.

--- a/platforms/kia_soul/firmware/brake/src/communications.cpp
+++ b/platforms/kia_soul/firmware/brake/src/communications.cpp
@@ -76,6 +76,8 @@ static void publish_brake_report( void )
     brake_report.data.pedal_output = (uint16_t) g_brake_control_state.current_sensor_brake_pressure;
     brake_report.data.fault_obd_timeout = (uint8_t) g_brake_control_state.obd_timeout;
     brake_report.data.fault_invalid_sensor_value = (uint8_t) g_brake_control_state.invalid_sensor_value;
+    brake_report.data.fault_startup_pressure_check_error = (uint8_t) g_brake_control_state.startup_pressure_check_error;
+    brake_report.data.fault_startup_pump_motor_check_error = (uint8_t) g_brake_control_state.startup_pump_motor_check_error;
 
     g_control_can.sendMsgBuf(
         brake_report.id,

--- a/platforms/kia_soul/firmware/brake/src/main.cpp
+++ b/platforms/kia_soul/firmware/brake/src/main.cpp
@@ -18,11 +18,11 @@ int main( void )
 {
     init_arduino( );
 
+    init_communication_interfaces( );
+
     init_globals( );
 
     init_devices( );
-
-    init_communication_interfaces( );
 
     wdt_enable( WDTO_120MS );
 

--- a/platforms/kia_soul/firmware/brake/tests/CMakeLists.txt
+++ b/platforms/kia_soul/firmware/brake/tests/CMakeLists.txt
@@ -3,6 +3,7 @@ project(kia-soul-brake-tests)
 add_library(
     kia-soul-brake
     SHARED
+    ../src/accumulator.cpp
     ../src/communications.cpp
     ../src/globals.cpp
     ../src/brake_control.cpp

--- a/platforms/kia_soul/firmware/brake/tests/features/checking_actuator_functionality.feature
+++ b/platforms/kia_soul/firmware/brake/tests/features/checking_actuator_functionality.feature
@@ -1,0 +1,23 @@
+# language: en
+
+Feature: Checking actuator functionality
+
+  Brake actuator should be checked for proper functionality on module startup.
+
+
+  Scenario: Startup checks fail
+    Given the actuator and pump motor are in a bad state
+
+    When the startup checks are run
+
+    Then the actuator error should be set to true
+    And the pump motor error should be set to true
+
+
+  Scenario: Startup checks pass
+    Given the actuator and pump motor are in a good state
+
+    When the startup checks are run
+
+    Then the actuator error should be set to false
+    And the pump motor error should be set to false

--- a/platforms/kia_soul/firmware/brake/tests/features/checking_sensor_validity.feature
+++ b/platforms/kia_soul/firmware/brake/tests/features/checking_sensor_validity.feature
@@ -12,7 +12,6 @@ Feature: Checking sensor validity
 
     Then control should remain enabled
 
-
   Scenario: A sensor becomes permanently disconnected
     Given brake control is enabled
 

--- a/platforms/kia_soul/firmware/brake/tests/features/step_definitions/checking_actuator_functionality.cpp
+++ b/platforms/kia_soul/firmware/brake/tests/features/step_definitions/checking_actuator_functionality.cpp
@@ -1,0 +1,57 @@
+GIVEN("^the actuator and pump motor are in a (.*) state$")
+{
+    REGEX_PARAM(std::string, state);
+
+    if( state == "bad" )
+    {
+        g_mock_arduino_analog_read_return = 0;
+    }
+    else if( state == "good" )
+    {
+        g_mock_arduino_analog_read_return = BRAKE_PRESSURE_SENSOR_CHECK_VALUE_MIN;
+    }
+}
+
+
+WHEN("^the startup checks are run$")
+{
+    brake_init();
+}
+
+
+THEN("^the actuator error should be set to (.*)")
+{
+    REGEX_PARAM(std::string, error_val);
+
+    if( error_val == "false" )
+    {
+        assert_that(
+            g_brake_control_state.startup_pressure_check_error,
+            is_equal_to(0));
+    }
+    else if( error_val == "true" )
+    {
+        assert_that(
+            g_brake_control_state.startup_pressure_check_error,
+            is_equal_to(1));
+    }
+}
+
+
+THEN("^the pump motor error should be set to (.*)")
+{
+    REGEX_PARAM(std::string, error_val);
+
+    if( error_val == "false" )
+    {
+        assert_that(
+            g_brake_control_state.startup_pressure_check_error,
+            is_equal_to(0));
+    }
+    else if( error_val == "true" )
+    {
+        assert_that(
+            g_brake_control_state.startup_pressure_check_error,
+            is_equal_to(1));
+    }
+}

--- a/platforms/kia_soul/firmware/brake/tests/features/step_definitions/checking_sensor_validity.cpp
+++ b/platforms/kia_soul/firmware/brake/tests/features/step_definitions/checking_sensor_validity.cpp
@@ -32,6 +32,7 @@ WHEN("^a sensor becomes permanently disconnected$")
     }
 }
 
+
 THEN("^control should remain enabled")
 {
     assert_that(

--- a/platforms/kia_soul/firmware/brake/tests/features/step_definitions/test.cpp
+++ b/platforms/kia_soul/firmware/brake/tests/features/step_definitions/test.cpp
@@ -1,5 +1,6 @@
 // include source files to prevent step files from conflicting with each other
 #include "common.cpp"
+#include "checking_actuator_functionality.cpp"
 #include "checking_sensor_validity.cpp"
 #include "receiving_commands.cpp"
 #include "receiving_reports.cpp"

--- a/platforms/kia_soul/firmware/brake/utils/serial_actuator/src/serial_actuator.cpp
+++ b/platforms/kia_soul/firmware/brake/utils/serial_actuator/src/serial_actuator.cpp
@@ -80,25 +80,6 @@ struct brake_data_s brakes =
     0                           // pedal_command
 };
 
-
-// *****************************************************
-// Function:    raw_adc_to_voltage
-//
-// Purpose:     Convert the raw ADC reading (0 - 1023)
-//              to a pressure (0 - 5V)
-//
-// Returns:     float - pressure
-//
-// Parameters:  input - raw ADC reading
-//
-// *****************************************************
-static float raw_adc_to_voltage( int16_t input )
-{
-    float voltage = ( ( float )input * ( 5.0 / 1023.0 ) );
-    return voltage;
-}
-
-
 // *****************************************************
 // Function:    print_pressure_info
 //
@@ -125,10 +106,10 @@ static void print_pressure_info()
     DEBUG_PRINT( pressure_at_tires.pressure_right );
 
     DEBUG_PRINT( ",PMC1," );
-    DEBUG_PRINT( master_cylinder.pressure1 );
+    DEBUG_PRINT( master_cylinder.sensor_1_pressure );
 
     DEBUG_PRINT( ",PMC2," );
-    DEBUG_PRINTLN( master_cylinder.pressure2 );
+    DEBUG_PRINTLN( master_cylinder.sensor_2_pressure );
 }
 
 
@@ -248,6 +229,11 @@ int main( void )
 
     init_communication_interfaces( );
 
+    digitalWrite(PIN_WHEEL_PRESSURE_CHECK_1, LOW);
+    digitalWrite(PIN_WHEEL_PRESSURE_CHECK_1, LOW);
+    pinMode(PIN_WHEEL_PRESSURE_CHECK_1, OUTPUT);
+    pinMode(PIN_WHEEL_PRESSURE_CHECK_1, OUTPUT);
+
     DEBUG_PRINTLN( "initialization complete" );
 
     while( true )
@@ -258,11 +244,18 @@ int main( void )
 
         process_serial( );
 
-        read_pressure_sensor( );
+        int pressure_at_tires_pressure_left_raw = analogRead( PIN_PRESSURE_SENSOR_FRONT_LEFT );
+        int pressure_at_tires_pressure_right_raw = analogRead( PIN_PRESSURE_SENSOR_FRONT_RIGHT );
+        pressure_at_tires.pressure_left = raw_adc_to_pressure(pressure_at_tires_pressure_left_raw);
+        pressure_at_tires.pressure_right = raw_adc_to_pressure(pressure_at_tires_pressure_right_raw);
 
-        accumulator.pressure = accumulator_read_pressure( );
+        int accumulator_pressure_raw = analogRead( PIN_ACCUMULATOR_PRESSURE_SENSOR );
+        accumulator.pressure = raw_adc_to_pressure(accumulator_pressure_raw);
 
-        master_cylinder_read_pressure( &master_cylinder );
+        int master_cylinder_sensor_1_pressure_raw = analogRead( PIN_MASTER_CYLINDER_PRESSURE_SENSOR_1 );
+        int master_cylinder_sensor_2_pressure_raw = analogRead( PIN_MASTER_CYLINDER_PRESSURE_SENSOR_2 );
+        master_cylinder.sensor_1_pressure = raw_adc_to_pressure(master_cylinder_sensor_1_pressure_raw);
+        master_cylinder.sensor_2_pressure = raw_adc_to_pressure(master_cylinder_sensor_2_pressure_raw);
 
         print_pressure_info( );
     }

--- a/utils/joystick_commander/include/oscc_interface.h
+++ b/utils/joystick_commander/include/oscc_interface.h
@@ -20,6 +20,8 @@ typedef struct
     bool operator_override;
     bool fault_brake_obd_timeout;
     bool fault_brake_invalid_sensor_value;
+    bool fault_brake_actuator_error;
+    bool fault_brake_pump_motor_error;
     bool fault_steering_obd_timeout;
     bool fault_steering_invalid_sensor_value;
     bool fault_throttle_invalid_sensor_value;

--- a/utils/joystick_commander/include/oscc_interface.h
+++ b/utils/joystick_commander/include/oscc_interface.h
@@ -18,11 +18,11 @@
 typedef struct
 {
     bool operator_override;
-    bool obd_timeout_brake;
-    bool obd_timeout_steering;
-    bool invalid_sensor_value_brake;
-    bool invalid_sensor_value_steering;
-    bool invalid_sensor_value_throttle;
+    bool fault_brake_obd_timeout;
+    bool fault_brake_invalid_sensor_value;
+    bool fault_steering_obd_timeout;
+    bool fault_steering_invalid_sensor_value;
+    bool fault_throttle_invalid_sensor_value;
 } oscc_status_s;
 
 

--- a/utils/joystick_commander/src/commander.c
+++ b/utils/joystick_commander/src/commander.c
@@ -597,6 +597,20 @@ static bool check_for_brake_faults( oscc_status_s * status)
 
             fault_occurred = true;
         }
+
+        if ( status->fault_brake_actuator_error == true )
+        {
+            printf( "Brake - Actuator Error Detected\n" );
+
+            fault_occurred = true;
+        }
+
+        if ( status->fault_brake_pump_motor_error == true )
+        {
+            printf( "Brake - Accumulator Pump Error Detected\n" );
+
+            fault_occurred = true;
+        }
     }
 
     return fault_occurred;

--- a/utils/joystick_commander/src/commander.c
+++ b/utils/joystick_commander/src/commander.c
@@ -870,7 +870,7 @@ int commander_high_frequency_update( )
 
         if ( brake_fault_occurred == true )
         {
-            return_code = oscc_interface_disable_brakes( );
+            return_code = commander_disable_controls( );
         }
 
 
@@ -878,7 +878,7 @@ int commander_high_frequency_update( )
 
         if ( steering_fault_occurred == true )
         {
-            return_code = oscc_interface_disable_steering( );
+            return_code = commander_disable_controls( );
         }
 
 
@@ -886,7 +886,7 @@ int commander_high_frequency_update( )
 
         if ( throttle_fault_occurred == true )
         {
-            return_code = oscc_interface_disable_throttle( );
+            return_code = commander_disable_controls( );
         }
     }
 

--- a/utils/joystick_commander/src/commander.c
+++ b/utils/joystick_commander/src/commander.c
@@ -566,6 +566,110 @@ static int command_steering( )
 }
 
 
+// *****************************************************
+// Function:    check_for_brake_faults
+//
+// Purpose:     Checks oscc_status_s struct for brake
+//              faults
+//
+// Returns:     bool - true if fault occurred
+//                   - false if no fault occurred
+//
+// Parameters:  oscc_status_s - struct containing OSCC status
+//
+// *****************************************************
+static bool check_for_brake_faults( oscc_status_s * status)
+{
+    bool fault_occurred = false;
+
+    if( status != NULL )
+    {
+        if ( status->fault_brake_obd_timeout == true )
+        {
+            printf( "Brake - OBD Timeout Detected\n" );
+
+            fault_occurred = true;
+        }
+
+        if ( status->fault_brake_invalid_sensor_value == true )
+        {
+            printf( "Brake - Invalid Sensor Value Detected\n" );
+
+            fault_occurred = true;
+        }
+    }
+
+    return fault_occurred;
+}
+
+
+// *****************************************************
+// Function:    check_for_steering_faults
+//
+// Purpose:     Checks oscc_status_s struct for steering
+//              faults
+//
+// Returns:     bool - true if fault occurred
+//                   - false if no fault occurred
+//
+// Parameters:  oscc_status_s - struct containing OSCC status
+//
+// *****************************************************
+static bool check_for_steering_faults( oscc_status_s * status)
+{
+    bool fault_occurred = false;
+
+    if( status != NULL )
+    {
+        if ( status->fault_steering_obd_timeout == true )
+        {
+            printf( "Steering - OBD Timeout Detected\n" );
+
+            fault_occurred = true;
+        }
+
+        if ( status->fault_steering_invalid_sensor_value == true )
+        {
+            printf( "Steering - Invalid Sensor Value Detected\n" );
+
+            fault_occurred = true;
+        }
+    }
+
+    return fault_occurred;
+}
+
+
+// *****************************************************
+// Function:    check_for_throttle_faults
+//
+// Purpose:     Checks oscc_status_s struct for throttle
+//              faults
+//
+// Returns:     bool - true if fault occurred
+//                   - false if no fault occurred
+//
+// Parameters:  oscc_status_s - struct containing OSCC status
+//
+// *****************************************************
+static bool check_for_throttle_faults( oscc_status_s * status)
+{
+    bool fault_occurred = false;
+
+    if( status != NULL )
+    {
+        if ( status->fault_throttle_invalid_sensor_value == true )
+        {
+            printf( "Throttle - Invalid Sensor Value Detected\n" );
+
+            fault_occurred = true;
+        }
+    }
+
+    return fault_occurred;
+}
+
+
 
 // *****************************************************
 // public definitions
@@ -739,43 +843,37 @@ int commander_high_frequency_update( )
 
     return_code = oscc_interface_update_status( &status );
 
-    if ( status.operator_override == true )
+    if ( return_code == NOERR )
     {
-        printf( "Driver Override Detected\n" );
-        return_code = commander_disable_controls( );
-    }
+        if ( status.operator_override == true )
+        {
+            printf( "Driver Override Detected\n" );
+            return_code = commander_disable_controls( );
+        }
 
-    if ( status.obd_timeout_brake == true )
-    {
-        printf( "Brake - OBD Timeout Detected\n" );
-        return_code = oscc_interface_disable_brakes( );
 
-    }
+        bool brake_fault_occurred = check_for_brake_faults( &status );
 
-    if ( status.obd_timeout_brake == true )
-    {
-        printf( "Steering - OBD Timeout Detected\n" );
+        if ( brake_fault_occurred == true )
+        {
+            return_code = oscc_interface_disable_brakes( );
+        }
 
-        return_code = oscc_interface_disable_steering( );
-    }
 
-    if ( status.invalid_sensor_value_brake == true )
-    {
-        printf( "Brake - Invalid Sensor Value Detected\n" );
-        return_code = oscc_interface_disable_steering( );
-    }
+        bool steering_fault_occurred = check_for_steering_faults( &status );
 
-    if ( status.invalid_sensor_value_steering == true )
-    {
-        printf( "Steering - Invalid Sensor Value Detected\n" );
-        return_code = oscc_interface_disable_steering( );
-    }
+        if ( steering_fault_occurred == true )
+        {
+            return_code = oscc_interface_disable_steering( );
+        }
 
-    if ( status.invalid_sensor_value_throttle == true )
-    {
-        printf( "Throttle - Invalid Sensor Value Detected\n" );
-        return_code = oscc_interface_disable_throttle( );
 
+        bool throttle_fault_occurred = check_for_throttle_faults( &status );
+
+        if ( throttle_fault_occurred == true )
+        {
+            return_code = oscc_interface_disable_throttle( );
+        }
     }
 
     return return_code;

--- a/utils/joystick_commander/src/oscc_interface.c
+++ b/utils/joystick_commander/src/oscc_interface.c
@@ -177,6 +177,8 @@ static void oscc_interface_check_brake_faults(
         status->operator_override = (bool) brake_report_data->override;
         status->fault_brake_obd_timeout = (bool) brake_report_data->fault_obd_timeout;
         status->fault_brake_invalid_sensor_value = (bool) brake_report_data->fault_invalid_sensor_value;
+        status->fault_brake_actuator_error = (bool) brake_report_data->fault_startup_pressure_check_error;
+        status->fault_brake_pump_motor_error = (bool) brake_report_data->fault_startup_pump_motor_check_error;
     }
 }
 


### PR DESCRIPTION
The brake firmware checks for sane values from the brake actuator on startup using the new sensor pins and reports a DTC if something is wrong.