### PR TITLE
Rust build/test cleanup

### DIFF
--- a/firmware/brake/tests/property/build.rs
+++ b/firmware/brake/tests/property/build.rs
@@ -16,7 +16,6 @@ fn main() {
         .include("../../../common/libs/time")
         .include("../../../common/libs/pid")
         .include("../../../../api/include")
-        .include("/usr/include")
         .file("../../../common/testing/mocks/Arduino_mock.cpp")
         .file("../../../common/testing/mocks/mcp_can_mock.cpp")
         .file("../../src/communications.cpp")
@@ -26,7 +25,6 @@ fn main() {
         .file("../../src/helper.cpp")
         .file("../../../common/libs/can/oscc_can.cpp")
         .cpp(true)
-        .compiler("/usr/bin/g++")
         .compile("libbrake_test.a");
 
     let out_dir = env::var("OUT_DIR").unwrap();

--- a/firmware/brake/tests/property/src/tests.rs
+++ b/firmware/brake/tests/property/src/tests.rs
@@ -12,21 +12,13 @@ extern crate rand;
 use quickcheck::{QuickCheck, TestResult, Arbitrary, Gen, StdGen};
 
 extern "C" {
-    #[link_name = "g_mock_mcp_can_check_receive_return"]
     pub static mut g_mock_mcp_can_check_receive_return: u8;
-    #[link_name = "g_mock_mcp_can_read_msg_buf_id"]
     pub static mut g_mock_mcp_can_read_msg_buf_id: u32;
-    #[link_name = "g_mock_mcp_can_read_msg_buf_buf"]
     pub static mut g_mock_mcp_can_read_msg_buf_buf: [u8; 8usize];
-    #[link_name = "g_mock_mcp_can_send_msg_buf_id"]
     pub static mut g_mock_mcp_can_send_msg_buf_id: u32;
-    #[link_name = "g_mock_mcp_can_send_msg_buf_ext"]
     pub static mut g_mock_mcp_can_send_msg_buf_ext: u8;
-    #[link_name = "g_mock_mcp_can_send_msg_buf_len"]
     pub static mut g_mock_mcp_can_send_msg_buf_len: u8;
-    #[link_name = "g_mock_mcp_can_send_msg_buf_buf"]
     pub static mut g_mock_mcp_can_send_msg_buf_buf: *mut u8;
-    #[link_name = "g_mock_arduino_analog_read_return"]
     pub static mut g_mock_arduino_analog_read_return: isize;
 }
 

--- a/firmware/common/libs/can/oscc_can.cpp
+++ b/firmware/common/libs/can/oscc_can.cpp
@@ -24,18 +24,18 @@ can_status_t check_for_rx_frame( MCP_CAN &can, can_frame_s * const frame )
 
     if( frame != NULL )
     {
+        memset( frame, 0, sizeof(*frame) );
+
         cli();
 
-        if( can.checkReceive( ) == CAN_MSGAVAIL )
+        int got_message = can.readMsgBufID(
+                ( uint32_t* ) &frame->id,
+                ( uint8_t* ) &frame->dlc,
+                ( uint8_t* ) frame->data );
+
+        if( got_message == CAN_OK )
         {
-            memset( frame, 0, sizeof(*frame) );
-
             frame->timestamp = millis( );
-
-            can.readMsgBufID(
-                    ( uint32_t* ) &frame->id,
-                    ( uint8_t* ) &frame->dlc,
-                    ( uint8_t* ) frame->data );
 
             ret = CAN_RX_FRAME_AVAILABLE;
         }

--- a/firmware/common/libs/pid/tests/property/build.rs
+++ b/firmware/common/libs/pid/tests/property/build.rs
@@ -9,7 +9,6 @@ fn main() {
         .flag("-w")
         .file("../../oscc_pid.cpp")
         .cpp(true)
-        .compiler("/usr/bin/g++")
         .compile("libpid_test.a");
 
     let out_dir = env::var("OUT_DIR").unwrap();

--- a/firmware/common/testing/mocks/mcp_can.h
+++ b/firmware/common/testing/mocks/mcp_can.h
@@ -22,7 +22,6 @@ class MCP_CAN
         uint8_t begin(uint8_t speedset);
         uint8_t sendMsgBuf(uint32_t id, uint8_t ext, uint8_t len, uint8_t *buf);
         uint8_t readMsgBufID(uint32_t *ID, uint8_t *len, uint8_t *buf);
-        uint8_t checkReceive(void);
 };
 
 #endif

--- a/firmware/common/testing/mocks/mcp_can_mock.cpp
+++ b/firmware/common/testing/mocks/mcp_can_mock.cpp
@@ -26,11 +26,6 @@ uint8_t MCP_CAN::begin(uint8_t speedset)
     return CAN_OK;
 }
 
-uint8_t MCP_CAN::checkReceive(void)
-{
-    return g_mock_mcp_can_check_receive_return;
-}
-
 uint8_t MCP_CAN::sendMsgBuf(uint32_t id, uint8_t ext, uint8_t len, uint8_t *buf)
 {
     g_mock_mcp_can_send_msg_buf_id = id;
@@ -46,6 +41,12 @@ uint8_t MCP_CAN::sendMsgBuf(uint32_t id, uint8_t ext, uint8_t len, uint8_t *buf)
 
 uint8_t MCP_CAN::readMsgBufID(uint32_t *ID, uint8_t *len, uint8_t *buf)
 {
+    if( g_mock_mcp_can_check_receive_return != CAN_MSGAVAIL)
+    {
+        *len = 0;
+        return CAN_NOMSG;
+    }
+
     *ID = g_mock_mcp_can_read_msg_buf_id;
     *len = 8;
 

--- a/firmware/steering/tests/property/build.rs
+++ b/firmware/steering/tests/property/build.rs
@@ -23,6 +23,7 @@ fn main() {
         .file("../../src/communications.cpp")
         .file("../../src/steering_control.cpp")
         .file("../../src/globals.cpp")
+        .cpp(true)
         .compile("libsteering_test.a");
 
     let out_dir = env::var("OUT_DIR").unwrap();

--- a/firmware/steering/tests/property/src/tests.rs
+++ b/firmware/steering/tests/property/src/tests.rs
@@ -13,27 +13,16 @@ use quickcheck::{QuickCheck, TestResult, Arbitrary, Gen, StdGen};
 use rand::Rng;
 
 extern "C" {
-    #[link_name = "g_mock_mcp_can_check_receive_return"]
     pub static mut g_mock_mcp_can_check_receive_return: u8;
-    #[link_name = "g_mock_mcp_can_read_msg_buf_id"]
     pub static mut g_mock_mcp_can_read_msg_buf_id: u32;
-    #[link_name = "g_mock_mcp_can_read_msg_buf_buf"]
     pub static mut g_mock_mcp_can_read_msg_buf_buf: [u8; 8usize];
-    #[link_name = "g_mock_mcp_can_send_msg_buf_id"]
     pub static mut g_mock_mcp_can_send_msg_buf_id: u32;
-    #[link_name = "g_mock_mcp_can_send_msg_buf_ext"]
     pub static mut g_mock_mcp_can_send_msg_buf_ext: u8;
-    #[link_name = "g_mock_mcp_can_send_msg_buf_len"]
     pub static mut g_mock_mcp_can_send_msg_buf_len: u8;
-    #[link_name = "g_mock_mcp_can_send_msg_buf_buf"]
     pub static mut g_mock_mcp_can_send_msg_buf_buf: *mut u8;
-    #[link_name = "g_mock_arduino_analog_read_return"]
     pub static mut g_mock_arduino_analog_read_return: isize;
-    #[link_name = "g_mock_dac_output_a"]
     pub static mut g_mock_dac_output_a: u16;
-    #[link_name = "g_mock_dac_output_b"]
     pub static mut g_mock_dac_output_b: u16;
-    #[link_name = "g_steering_control_state"]
     pub static mut g_steering_control_state: steering_control_state_s;
 }
 

--- a/firmware/throttle/tests/property/build.rs
+++ b/firmware/throttle/tests/property/build.rs
@@ -23,6 +23,7 @@ fn main() {
         .file("../../src/communications.cpp")
         .file("../../src/throttle_control.cpp")
         .file("../../src/globals.cpp")
+        .cpp(true)
         .compile("libthrottle_test.a");
 
     let out_dir = env::var("OUT_DIR").unwrap();

--- a/firmware/throttle/tests/property/src/tests.rs
+++ b/firmware/throttle/tests/property/src/tests.rs
@@ -13,27 +13,16 @@ use quickcheck::{QuickCheck, TestResult, Arbitrary, StdGen, Gen};
 use rand::Rng;
 
 extern "C" {
-    #[link_name = "g_mock_mcp_can_check_receive_return"]
     pub static mut g_mock_mcp_can_check_receive_return: u8;
-    #[link_name = "g_mock_mcp_can_read_msg_buf_id"]
     pub static mut g_mock_mcp_can_read_msg_buf_id: u32;
-    #[link_name = "g_mock_mcp_can_read_msg_buf_buf"]
     pub static mut g_mock_mcp_can_read_msg_buf_buf: [u8; 8usize];
-    #[link_name = "g_mock_mcp_can_send_msg_buf_id"]
     pub static mut g_mock_mcp_can_send_msg_buf_id: u32;
-    #[link_name = "g_mock_mcp_can_send_msg_buf_ext"]
     pub static mut g_mock_mcp_can_send_msg_buf_ext: u8;
-    #[link_name = "g_mock_mcp_can_send_msg_buf_len"]
     pub static mut g_mock_mcp_can_send_msg_buf_len: u8;
-    #[link_name = "g_mock_mcp_can_send_msg_buf_buf"]
     pub static mut g_mock_mcp_can_send_msg_buf_buf: *mut u8;
-    #[link_name = "g_mock_arduino_analog_read_return"]
     pub static mut g_mock_arduino_analog_read_return: isize;
-    #[link_name = "g_mock_dac_output_a"]
     pub static mut g_mock_dac_output_a: u16;
-    #[link_name = "g_mock_dac_output_b"]
     pub static mut g_mock_dac_output_b: u16;
-    #[link_name = "g_throttle_control_state"]
     pub static mut g_throttle_control_state: throttle_control_state_s;
 }
 


### PR DESCRIPTION
These are some cleanups I've spotted while reviewing the property-based tests in OSCC. I don't have hardware to test these changes on, so @k-cleary, please test this PR on real hardware before approving. I also haven't been able to get the unit tests to build yet (I'll follow up with @austinjmorlan about that separately I guess), but the property-based tests do still pass.