### PR TITLE
Add Steering Override

### DIFF
--- a/api/include/vehicles/kia_soul.h
+++ b/api/include/vehicles/kia_soul.h
@@ -281,13 +281,13 @@ typedef struct
  * @brief Minimum allowable torque value.
  *
  */
-#define MINIMUM_TORQUE_COMMAND ( -10.0 )
+#define MINIMUM_TORQUE_COMMAND ( -12.8 )
 
 /*
  * @brief Maximum allowable torque value.
  *
  */
-#define MAXIMUM_TORQUE_COMMAND ( 10.0 )
+#define MAXIMUM_TORQUE_COMMAND ( 12.7 )
 
 /*
  * @brief Minimum allowable steering DAC output. [volts]
@@ -345,25 +345,25 @@ typedef struct
  * @brief Scalar value for the low spoof signal taken from a calibration curve.
  *
  */
-#define TORQUE_SPOOF_LOW_SIGNAL_CALIBRATION_CURVE_SCALE ( 0.17 )
+#define TORQUE_SPOOF_LOW_SIGNAL_CALIBRATION_CURVE_SCALE ( 0.135 )
 
 /*
  * @brief Offset value for the low spoof signal taken from a calibration curve.
  *
  */
-#define TORQUE_SPOOF_LOW_SIGNAL_CALIBRATION_CURVE_OFFSET ( 2.40 )
+#define TORQUE_SPOOF_LOW_SIGNAL_CALIBRATION_CURVE_OFFSET ( 2.39 )
 
 /*
  * @brief Scalar value for the high spoof signal taken from a calibration curve.
  *
  */
-#define TORQUE_SPOOF_HIGH_SIGNAL_CALIBRATION_CURVE_SCALE ( -0.16 )
+#define TORQUE_SPOOF_HIGH_SIGNAL_CALIBRATION_CURVE_SCALE ( -0.145 )
 
 /*
  * @brief Offset value for the high spoof signal taken from a calibration curve.
  *
  */
-#define TORQUE_SPOOF_HIGH_SIGNAL_CALIBRATION_CURVE_OFFSET ( 2.5 )
+#define TORQUE_SPOOF_HIGH_SIGNAL_CALIBRATION_CURVE_OFFSET ( 2.42 )
 
 /*
  * @brief Minimum allowed value for the high spoof signal value.
@@ -382,11 +382,11 @@ typedef struct
             + TORQUE_SPOOF_LOW_SIGNAL_CALIBRATION_CURVE_OFFSET))
 
 /*
- * @brief Value of the torque sensor that indicates operator override.
- *        [degrees/microsecond]
+ * @brief Value of torque sensor difference that indicates likely operator 
+ *        override.
  *
  */
-#define OVERRIDE_WHEEL_THRESHOLD_IN_DEGREES_PER_USEC ( 750 )
+#define TORQUE_DIFFERENCE_THRESHOLD ( 2500 )
 
 
 

--- a/api/include/vehicles/kia_soul.h
+++ b/api/include/vehicles/kia_soul.h
@@ -386,7 +386,7 @@ typedef struct
  *        override.
  *
  */
-#define TORQUE_DIFFERENCE_THRESHOLD ( 2500 )
+#define TORQUE_DIFFERENCE_OVERRIDE_THRESHOLD ( 1600 )
 
 
 

--- a/firmware/brake/tests/features/step_definitions/checking_faults.cpp
+++ b/firmware/brake/tests/features/step_definitions/checking_faults.cpp
@@ -1,6 +1,7 @@
 WHEN("^a sensor becomes temporarily disconnected$")
 {
-    g_mock_arduino_analog_read_return = 0;
+    g_mock_arduino_analog_read_return[0] = 0;
+    g_mock_arduino_analog_read_return[1] = 0;
 
     check_for_sensor_faults();
 
@@ -12,7 +13,8 @@ WHEN("^a sensor becomes temporarily disconnected$")
 
 WHEN("^a sensor becomes permanently disconnected$")
 {
-    g_mock_arduino_analog_read_return = 0;
+    g_mock_arduino_analog_read_return[0] = 0;
+    g_mock_arduino_analog_read_return[1] = 0;
 
     // must call function enough times to exceed the fault limit
     for( int i = 0; i < 100; ++i )
@@ -34,7 +36,8 @@ WHEN("^the operator applies (.*) to the brake pedal$")
 {
     REGEX_PARAM(int, pedal_val);
 
-    g_mock_arduino_analog_read_return = pedal_val;
+    g_mock_arduino_analog_read_return[10] = pedal_val;
+    g_mock_arduino_analog_read_return[11] = pedal_val;
 
     check_for_operator_override();
 

--- a/firmware/brake/tests/features/step_definitions/common.cpp
+++ b/firmware/brake/tests/features/step_definitions/common.cpp
@@ -21,7 +21,7 @@ extern unsigned long g_mock_arduino_micros_return;
 extern uint8_t g_mock_arduino_digital_write_pin;
 extern uint8_t g_mock_arduino_digital_write_val;
 
-extern int g_mock_arduino_analog_read_return;
+extern int g_mock_arduino_analog_read_return[100];
 extern int g_mock_arduino_analog_write_count;
 extern uint8_t g_mock_arduino_analog_write_pins[100];
 extern int g_mock_arduino_analog_write_val[100];
@@ -43,7 +43,7 @@ BEFORE()
     g_mock_arduino_digital_write_pin = UINT8_MAX;
     g_mock_arduino_digital_write_val = UINT8_MAX;
 
-    g_mock_arduino_analog_read_return = INT_MAX;
+    g_mock_arduino_analog_read_return[0] = INT_MAX;
     g_mock_arduino_analog_write_count = 0;
     memset(&g_mock_arduino_analog_write_pins, 0, sizeof(g_mock_arduino_analog_write_pins));
     memset(&g_mock_arduino_analog_write_val, 0, sizeof(g_mock_arduino_analog_write_val));

--- a/firmware/brake/tests/features/step_definitions/receiving_messages.cpp
+++ b/firmware/brake/tests/features/step_definitions/receiving_messages.cpp
@@ -11,7 +11,8 @@ GIVEN("^the left brake sensor reads (.*)$")
 {
     REGEX_PARAM(int, sensor_val);
 
-    g_mock_arduino_analog_read_return = sensor_val;
+    g_mock_arduino_analog_read_return[14] = sensor_val;
+    g_mock_arduino_analog_read_return[14] = sensor_val;
 }
 
 
@@ -19,7 +20,8 @@ GIVEN("^the right brake sensor reads (.*)$")
 {
     REGEX_PARAM(int, sensor_val);
 
-    g_mock_arduino_analog_read_return = sensor_val;
+    g_mock_arduino_analog_read_return[13] = sensor_val;
+    g_mock_arduino_analog_read_return[13] = sensor_val;
 }
 
 

--- a/firmware/brake/tests/features/step_definitions/receiving_messages.cpp
+++ b/firmware/brake/tests/features/step_definitions/receiving_messages.cpp
@@ -12,7 +12,6 @@ GIVEN("^the left brake sensor reads (.*)$")
     REGEX_PARAM(int, sensor_val);
 
     g_mock_arduino_analog_read_return[14] = sensor_val;
-    g_mock_arduino_analog_read_return[14] = sensor_val;
 }
 
 
@@ -20,7 +19,6 @@ GIVEN("^the right brake sensor reads (.*)$")
 {
     REGEX_PARAM(int, sensor_val);
 
-    g_mock_arduino_analog_read_return[13] = sensor_val;
     g_mock_arduino_analog_read_return[13] = sensor_val;
 }
 

--- a/firmware/common/testing/mocks/Arduino_mock.cpp
+++ b/firmware/common/testing/mocks/Arduino_mock.cpp
@@ -9,7 +9,7 @@ unsigned long g_mock_arduino_millis_return;
 unsigned long g_mock_arduino_micros_return;
 uint8_t g_mock_arduino_digital_write_pin;
 uint8_t g_mock_arduino_digital_write_val;
-int g_mock_arduino_analog_read_return;
+int g_mock_arduino_analog_read_return[100];
 uint8_t g_mock_arduino_analog_write_pins[100];
 int g_mock_arduino_analog_write_val[100];
 int g_mock_arduino_analog_write_count;
@@ -39,7 +39,7 @@ void digitalWrite(uint8_t pin, uint8_t val)
 
 int analogRead(uint8_t pin)
 {
-    return g_mock_arduino_analog_read_return;
+    return g_mock_arduino_analog_read_return[pin];
 }
 
 void analogWrite(uint8_t pin, int val)

--- a/firmware/steering/src/steering_control.cpp
+++ b/firmware/steering/src/steering_control.cpp
@@ -75,8 +75,8 @@ void check_for_sensor_faults( void )
         read_torque_sensor(&torque);
 
         // sensor pins tied to ground - a value of zero indicates disconnection
-        if( (torque.high == -1)
-            || (torque.low == -1) )
+        if( (torque.high == 0)
+            || (torque.low == 0) )
         {
             ++fault_count;
 

--- a/firmware/steering/src/steering_control.cpp
+++ b/firmware/steering/src/steering_control.cpp
@@ -25,23 +25,13 @@
  */
 #define SENSOR_VALIDITY_CHECK_FAULT_COUNT ( 4 )
 
-/*
- * @brief Number of consecutive faults that can occur when reading the
- *        torque sensor before an operator override is reported.
- *
- */
-#define OPERATOR_OVERRIDE_CHECK_FAULT_COUNT ( 4 )
-
-/*
- * @brief Value of torque sensor difference that indicates likely operator 
- *        override.
- *
- */
-#define TORQUE_DIFFERENCE_THRESHOLD ( 2500 )
-
-
 static void read_torque_sensor(
     steering_torque_s * value );
+
+static float exponential_moving_average(
+    const float alpha,
+    const float input,
+    const float average );
 
 
 void check_for_operator_override( void )
@@ -185,7 +175,7 @@ void disable_control( void )
     }
 }
 
-float exponential_moving_average(
+static float exponential_moving_average(
     const float alpha,
     const float input,
     const float average )

--- a/firmware/steering/src/steering_control.cpp
+++ b/firmware/steering/src/steering_control.cpp
@@ -44,21 +44,21 @@ void check_for_operator_override( void )
 
         read_torque_sensor( &torque );
 
-        uint16_t unfiltered_diff = abs((int)torque.high - (int)torque.low);
+        uint16_t unfiltered_diff = abs( ( int )torque.high - ( int )torque.low );
 
         const float filter_alpha = 0.01;
 
-        if (filtered_diff == 0)
+        if ( filtered_diff == 0 )
         {
             filtered_diff = unfiltered_diff;
         }
 
         filtered_diff = exponential_moving_average(
-        filter_alpha,
-        unfiltered_diff,
-        filtered_diff);
+            filter_alpha,
+            unfiltered_diff,
+            filtered_diff);
 
-        if( abs(filtered_diff) > TORQUE_DIFFERENCE_OVERRIDE_THRESHOLD)
+        if( abs( filtered_diff ) > TORQUE_DIFFERENCE_OVERRIDE_THRESHOLD )
         {
             disable_control( );
 

--- a/firmware/steering/tests/features/checking_faults.feature
+++ b/firmware/steering/tests/features/checking_faults.feature
@@ -1,6 +1,6 @@
 # language: en
 
-Feature: Checking for fauls
+Feature: Checking for faults
 
   If the module encounters a fault condition, it should disable control and
   publish a fault report.

--- a/firmware/steering/tests/features/step_definitions/checking_faults.cpp
+++ b/firmware/steering/tests/features/step_definitions/checking_faults.cpp
@@ -1,6 +1,7 @@
 WHEN("^a sensor becomes temporarily disconnected$")
 {
-    g_mock_arduino_analog_read_return = 0;
+    g_mock_arduino_analog_read_return[0] = 0;
+    g_mock_arduino_analog_read_return[1] = 0;
 
     check_for_sensor_faults();
 
@@ -12,7 +13,8 @@ WHEN("^a sensor becomes temporarily disconnected$")
 
 WHEN("^a sensor becomes permanently disconnected$")
 {
-    g_mock_arduino_analog_read_return = 0;
+    g_mock_arduino_analog_read_return[0] = 0;
+    g_mock_arduino_analog_read_return[1] = 0;
 
     // must call function enough times to exceed the fault limit
     for( int i = 0; i < 100; ++i )
@@ -34,9 +36,15 @@ WHEN("^the operator applies (.*) to the steering wheel$")
 {
     REGEX_PARAM(int, steering_sensor_val);
 
-    g_mock_arduino_analog_read_return = steering_sensor_val;
+    g_mock_arduino_analog_read_return[0] = steering_sensor_val;
+    g_mock_arduino_analog_read_return[1] = 0;
 
-    check_for_operator_override();
+    // need to call since newest read only contributes 1% for smoothing
+    // and the average will start at 0.0 for the tests
+    for( int i = 0; i < 200; ++i )
+    {
+        check_for_operator_override();
+    }
 }
 
 

--- a/firmware/steering/tests/features/step_definitions/common.cpp
+++ b/firmware/steering/tests/features/step_definitions/common.cpp
@@ -19,7 +19,7 @@ using namespace cgreen;
 extern uint8_t g_mock_arduino_digital_write_pin;
 extern uint8_t g_mock_arduino_digital_write_val;
 
-extern int g_mock_arduino_analog_read_return;
+extern int g_mock_arduino_analog_read_return[100];
 
 extern uint8_t g_mock_mcp_can_check_receive_return;
 extern uint32_t g_mock_mcp_can_read_msg_buf_id;
@@ -41,7 +41,8 @@ BEFORE()
     g_mock_arduino_digital_write_pin = UINT8_MAX;
     g_mock_arduino_digital_write_val = UINT8_MAX;
 
-    g_mock_arduino_analog_read_return = INT_MAX;
+    g_mock_arduino_analog_read_return[0] = INT_MAX;
+    g_mock_arduino_analog_read_return[1] = INT_MAX;
 
     g_mock_mcp_can_check_receive_return = UINT8_MAX;
     g_mock_mcp_can_read_msg_buf_id = UINT32_MAX;
@@ -76,7 +77,8 @@ GIVEN("^the torque sensors have a reading of (.*)$")
 {
     REGEX_PARAM(int, sensor_val);
 
-    g_mock_arduino_analog_read_return = sensor_val;
+    g_mock_arduino_analog_read_return[0] = sensor_val;
+    g_mock_arduino_analog_read_return[1] = sensor_val;
 }
 
 
@@ -84,7 +86,8 @@ GIVEN("^the operator has applied (.*) to the steering wheel$")
 {
     REGEX_PARAM(int, steering_sensor_val);
 
-    g_mock_arduino_analog_read_return = steering_sensor_val;
+    g_mock_arduino_analog_read_return[0] = steering_sensor_val;
+    g_mock_arduino_analog_read_return[1] = steering_sensor_val;
 
     check_for_operator_override();
 }

--- a/firmware/steering/tests/property/build.rs
+++ b/firmware/steering/tests/property/build.rs
@@ -5,7 +5,7 @@ use std::env;
 use std::path::Path;
 
 fn main() {
-    gcc::Config::new()
+    gcc::Build::new()
         .flag("-w")
         .define("KIA_SOUL", Some("ON"))
         .include("include")
@@ -48,8 +48,9 @@ fn main() {
         .whitelisted_var("OSCC_STEERING_COMMAND_CAN_ID")
         .whitelisted_var("OSCC_STEERING_COMMAND_CAN_DLC")
         .whitelisted_var("OSCC_FAULT_REPORT_CAN_ID")
-        .whitelisted_var("OSCC_STEERING_REPORT_PUBLISH_INTERVAL_IN_MSEC")
-        .whitelisted_var("OVERRIDE_WHEEL_THRESHOLD_IN_DEGREES_PER_USEC")
+        .whitelisted_var("PIN_TORQUE_SENSOR_HIGH")
+        .whitelisted_var("PIN_TORQUE_SENSOR_LOW")
+        .whitelisted_var("TORQUE_DIFFERENCE_THRESHOLD")
         .whitelisted_var("STEERING_SPOOF_LOW_SIGNAL_RANGE_MIN")
         .whitelisted_var("STEERING_SPOOF_LOW_SIGNAL_RANGE_MAX")
         .whitelisted_var("STEERING_SPOOF_HIGH_SIGNAL_RANGE_MIN")

--- a/firmware/steering/tests/property/build.rs
+++ b/firmware/steering/tests/property/build.rs
@@ -50,7 +50,7 @@ fn main() {
         .whitelisted_var("OSCC_FAULT_REPORT_CAN_ID")
         .whitelisted_var("PIN_TORQUE_SENSOR_HIGH")
         .whitelisted_var("PIN_TORQUE_SENSOR_LOW")
-        .whitelisted_var("TORQUE_DIFFERENCE_THRESHOLD")
+        .whitelisted_var("TORQUE_DIFFERENCE_OVERRIDE_THRESHOLD")
         .whitelisted_var("STEERING_SPOOF_LOW_SIGNAL_RANGE_MIN")
         .whitelisted_var("STEERING_SPOOF_LOW_SIGNAL_RANGE_MAX")
         .whitelisted_var("STEERING_SPOOF_HIGH_SIGNAL_RANGE_MIN")

--- a/firmware/steering/tests/property/src/tests.rs
+++ b/firmware/steering/tests/property/src/tests.rs
@@ -258,7 +258,7 @@ fn prop_check_operator_override(analog_read_spoof_high: i16, analog_read_spoof_l
 
         check_for_operator_override();
 
-        if (analog_read_spoof_high - analog_read_spoof_low) >= (TORQUE_DIFFERENCE_THRESHOLD as i16) {
+        if (analog_read_spoof_high - analog_read_spoof_low) >= (TORQUE_DIFFERENCE_OVERRIDE_THRESHOLD as i16) {
             TestResult::from_bool(g_steering_control_state.operator_override == true && g_steering_control_state.enabled == false &&
             g_mock_mcp_can_send_msg_buf_id == OSCC_FAULT_REPORT_CAN_ID)
         } else {

--- a/firmware/throttle/tests/features/step_definitions/checking_faults.cpp
+++ b/firmware/throttle/tests/features/step_definitions/checking_faults.cpp
@@ -1,6 +1,7 @@
 WHEN("^a sensor becomes temporarily disconnected$")
 {
-    g_mock_arduino_analog_read_return = 0;
+    g_mock_arduino_analog_read_return[0] = 0;
+    g_mock_arduino_analog_read_return[1] = 0;
 
     check_for_sensor_faults();
 
@@ -12,7 +13,8 @@ WHEN("^a sensor becomes temporarily disconnected$")
 
 WHEN("^a sensor becomes permanently disconnected$")
 {
-    g_mock_arduino_analog_read_return = 0;
+    g_mock_arduino_analog_read_return[0] = 0;
+    g_mock_arduino_analog_read_return[1] = 0;
 
     // must call function enough times to exceed the fault limit
     for( int i = 0; i < 100; ++i )
@@ -34,7 +36,8 @@ WHEN("^the operator applies (.*) to the accelerator$")
 {
     REGEX_PARAM(int, throttle_sensor_val);
 
-    g_mock_arduino_analog_read_return = throttle_sensor_val;
+    g_mock_arduino_analog_read_return[0] = throttle_sensor_val;
+    g_mock_arduino_analog_read_return[1] = throttle_sensor_val;
 
     check_for_operator_override();
 }

--- a/firmware/throttle/tests/features/step_definitions/common.cpp
+++ b/firmware/throttle/tests/features/step_definitions/common.cpp
@@ -19,7 +19,7 @@ using namespace cgreen;
 extern uint8_t g_mock_arduino_digital_write_pin;
 extern uint8_t g_mock_arduino_digital_write_val;
 
-extern int g_mock_arduino_analog_read_return;
+extern int g_mock_arduino_analog_read_return[100];
 
 extern uint8_t g_mock_mcp_can_check_receive_return;
 extern uint32_t g_mock_mcp_can_read_msg_buf_id;
@@ -41,7 +41,8 @@ BEFORE()
     g_mock_arduino_digital_write_pin = UINT8_MAX;
     g_mock_arduino_digital_write_val = UINT8_MAX;
 
-    g_mock_arduino_analog_read_return = INT_MAX;
+    g_mock_arduino_analog_read_return[0] = INT_MAX;
+    g_mock_arduino_analog_read_return[1] = INT_MAX;
 
     g_mock_mcp_can_check_receive_return = UINT8_MAX;
     g_mock_mcp_can_read_msg_buf_id = UINT32_MAX;
@@ -76,7 +77,8 @@ GIVEN("^the accelerator position sensors have a reading of (.*)$")
 {
     REGEX_PARAM(int, sensor_val);
 
-    g_mock_arduino_analog_read_return = sensor_val;
+    g_mock_arduino_analog_read_return[0] = sensor_val;
+    g_mock_arduino_analog_read_return[1] = sensor_val;
 }
 
 
@@ -85,7 +87,8 @@ GIVEN("^the operator has applied (.*) to the accelerator$")
 
     REGEX_PARAM(int, throttle_sensor_val);
 
-    g_mock_arduino_analog_read_return = throttle_sensor_val;
+    g_mock_arduino_analog_read_return[0] = throttle_sensor_val;
+    g_mock_arduino_analog_read_return[1] = throttle_sensor_val;
 
     check_for_operator_override();
 }

--- a/firmware/throttle/tests/property/src/tests.rs
+++ b/firmware/throttle/tests/property/src/tests.rs
@@ -20,7 +20,7 @@ extern "C" {
     pub static mut g_mock_mcp_can_send_msg_buf_ext: u8;
     pub static mut g_mock_mcp_can_send_msg_buf_len: u8;
     pub static mut g_mock_mcp_can_send_msg_buf_buf: *mut u8;
-    pub static mut g_mock_arduino_analog_read_return: isize;
+    pub static mut g_mock_arduino_analog_read_return: [isize; 8usize];
     pub static mut g_mock_dac_output_a: u16;
     pub static mut g_mock_dac_output_b: u16;
     pub static mut g_throttle_control_state: throttle_control_state_s;
@@ -254,7 +254,8 @@ fn prop_check_operator_override(analog_read_spoof: u16) -> TestResult {
     unsafe {
         g_throttle_control_state.enabled = true;
         g_throttle_control_state.operator_override = false;
-        g_mock_arduino_analog_read_return = analog_read_spoof as isize;
+        g_mock_arduino_analog_read_return[0] = analog_read_spoof as isize;
+        g_mock_arduino_analog_read_return[1] = analog_read_spoof as isize;
 
         check_for_operator_override();
 
@@ -271,7 +272,6 @@ fn prop_check_operator_override(analog_read_spoof: u16) -> TestResult {
 fn check_operator_override() {
     QuickCheck::new()
         .tests(1000)
-        .gen(StdGen::new(rand::thread_rng(), u16::max_value() as usize))
         .quickcheck(prop_check_operator_override as fn(u16) -> TestResult)
 }
 


### PR DESCRIPTION
Prior to this PR, we had no way of detecting steering operator overrides with the current model of allowing the full range of allowable outputs, not limiting anything except for where it would fault the vehicle. This PR applies a smoothing filter to the analogRead function of the steering module to smooth out noisy cases where the wheel hits the mechanical limits of the steering rack, allowing us to detect when the differential value is consistently higher or lower than the baseline, which indicates operator interference and triggers an override. 