### PR TITLE
Fix silent fail when writing to the socket

### DIFF
--- a/api/src/oscc.c
+++ b/api/src/oscc.c
@@ -428,6 +428,10 @@ static oscc_result_t oscc_can_write( long id, void *msg, unsigned int dlc )
         {
             ret = OSCC_OK;
         }
+        else
+        {
+            printf( "Could not write to socket: %s\n", strerror(errno) );
+        }
     }
 
     return ret;
@@ -535,7 +539,7 @@ static oscc_result_t oscc_init_can( const char *can_channel )
 
         if ( bytes_written < 0 )
         {
-            printf( "failed to write test frame to %s\n", can_channel );
+            printf( "Failed to write test frame to %s: %s\n", can_channel, strerror(errno) );
 
             ret = OSCC_ERROR;
         }


### PR DESCRIPTION
Prior to this commit, if a write() to the socket failed, it would
silently die with no information. This commit adds printing of the errno
string explaining the error so the user has context for the failure.