### PR TITLE
Initialize sigaction struct to zero

### DIFF
--- a/api/src/oscc.c
+++ b/api/src/oscc.c
@@ -540,6 +540,7 @@ oscc_result_t oscc_init_can( const char *can_channel )
 
     memset(&sig, 0, sizeof(sig));
     sigemptyset(&sig.sa_mask);
+    sig.sa_flags = SA_RESTART;
     sig.sa_handler = oscc_update_status;
     sigaction( SIGIO, &sig, NULL );
 

--- a/api/src/oscc.c
+++ b/api/src/oscc.c
@@ -519,14 +519,14 @@ oscc_result_t oscc_async_enable( int socket )
 
     if ( ret < 0 )
     {
-        printf( "set own failed\n" );
+        printf( "Setting owner process of socket failed: %s\n", strerror(errno) );
     }
 
     ret = fcntl( socket, F_SETFL, FASYNC | O_NONBLOCK );
 
     if ( ret < 0 )
     {
-        printf( "set async failed\n" );
+        printf( "Setting nonblocking asynchronous socket I/O failed: %s\n", strerror(errno) );
     }
 
     return ret;
@@ -537,6 +537,9 @@ oscc_result_t oscc_init_can( const char *can_channel )
     int ret = OSCC_OK;
 
     struct sigaction sig;
+
+    memset(&sig, 0, sizeof(sig));
+    sigemptyset(&sig.sa_mask);
     sig.sa_handler = oscc_update_status;
     sigaction( SIGIO, &sig, NULL );
 
@@ -544,7 +547,7 @@ oscc_result_t oscc_init_can( const char *can_channel )
 
     if ( s < 0 )
     {
-        printf( "opening can socket failed\n" );
+        printf( "Opening CAN socket failed: %s\n", strerror(errno) );
 
         ret = OSCC_ERROR;
     }
@@ -561,7 +564,7 @@ oscc_result_t oscc_init_can( const char *can_channel )
 
         if ( status < 0 )
         {
-            printf( "finding can index failed\n" );
+            printf( "Finding CAN index failed: %s\n", strerror(errno) );
 
             ret = OSCC_ERROR;
         }
@@ -580,7 +583,7 @@ oscc_result_t oscc_init_can( const char *can_channel )
 
         if ( status < 0 )
         {
-            printf( "socket binding failed\n" );
+            printf( "Socket binding failed: %s\n", strerror(errno) );
 
             ret = OSCC_ERROR;
         }
@@ -592,7 +595,7 @@ oscc_result_t oscc_init_can( const char *can_channel )
 
         if ( status != OSCC_OK )
         {
-            printf( "async enable failed\n" );
+            printf( "Enabling asynchronous socket I/O failed\n" );
 
             ret = OSCC_ERROR;
         }


### PR DESCRIPTION
Prior to this commit, the sigaction struct used to register the SIGIO
signal handler on CAN frame reception was not initialized to zero which
caused occasional strange behavior due to the undefined contents of the
sa_flags and sa_mask fields of the struct. This commit initializes the
struct to zeros before use to ensure it is in a known state.