### PR TITLE
Add a cmake configuration file

### DIFF
--- a/api/OsccConfig.cmake
+++ b/api/OsccConfig.cmake
@@ -1,0 +1,7 @@
+if(KIA_SOUL)
+    add_definitions(-DKIA_SOUL)
+elseif(KIA_SOUL_EV)
+    add_definitions(-DKIA_SOUL_EV)
+else()
+    message(FATAL_ERROR "No platform selected")
+endif()


### PR DESCRIPTION
This pull request removes the requirement of the OSCC API user from having to track which cars are and are not supported by keeping a configuration file within the API that CMakeLists.txt can point to. Rather than having to write the if block below in anything using the API the user would be able to write the following in their CMakeLists.txt file when using OSCC as a submodule:

```
cmake_minimum_required(VERSION 2.8.3)
project(demo_app)

include(oscc/api/OsccConfig.cmake)
```