### PR TITLE
Clean up API and firmware for style

### DIFF
--- a/api/include/oscc.h
+++ b/api/include/oscc.h
@@ -8,12 +8,14 @@
 #ifndef _OSCC_H
 #define _OSCC_H
 
-#include <stdbool.h>
+
 #include <linux/can.h>
+
 #include "can_protocols/brake_can_protocol.h"
 #include "can_protocols/fault_can_protocol.h"
-#include "can_protocols/throttle_can_protocol.h"
 #include "can_protocols/steering_can_protocol.h"
+#include "can_protocols/throttle_can_protocol.h"
+#include "vehicles.h"
 
 
 typedef enum

--- a/api/src/oscc.c
+++ b/api/src/oscc.c
@@ -454,6 +454,7 @@ oscc_result_t oscc_disable_steering( void )
 void oscc_update_status( )
 {
     struct can_frame rx_frame;
+    memset( &rx_frame, 0, sizeof(rx_frame) );
 
     if ( can_socket != -1 )
     {
@@ -527,6 +528,7 @@ oscc_result_t oscc_can_write( long id, void *msg, unsigned int dlc )
     {
         struct can_frame tx_frame;
 
+        memset( &tx_frame, 0, sizeof(tx_frame) );
         tx_frame.can_id = id;
         tx_frame.can_dlc = dlc;
         memcpy( tx_frame.data, msg, dlc );
@@ -588,8 +590,8 @@ oscc_result_t oscc_init_can( const char *can_channel )
 
     struct sigaction sig;
 
-    memset(&sig, 0, sizeof(sig));
-    sigemptyset(&sig.sa_mask);
+    memset( &sig, 0, sizeof(sig) );
+    sigemptyset( &sig.sa_mask );
     sig.sa_flags = SA_RESTART;
     sig.sa_handler = oscc_update_status;
     sigaction( SIGIO, &sig, NULL );
@@ -607,6 +609,7 @@ oscc_result_t oscc_init_can( const char *can_channel )
 
 
     struct ifreq ifr;
+    memset( &ifr, 0, sizeof(ifr) );
 
     if ( result == OSCC_OK )
     {
@@ -627,6 +630,7 @@ oscc_result_t oscc_init_can( const char *can_channel )
     {
         struct sockaddr_can can_address;
 
+        memset( &can_address, 0, sizeof(can_address) );
         can_address.can_family = AF_CAN;
         can_address.can_ifindex = ifr.ifr_ifindex;
 
@@ -663,9 +667,9 @@ oscc_result_t oscc_init_can( const char *can_channel )
            if it is valid */
         struct can_frame tx_frame;
 
+        memset( &tx_frame, 0, sizeof(tx_frame) );
         tx_frame.can_id = 0;
         tx_frame.can_dlc = 8;
-        memset( tx_frame.data, 0, sizeof(tx_frame.data) );
 
         int bytes_written = write( sock, &tx_frame, sizeof(tx_frame) );
 

--- a/api/src/oscc.c
+++ b/api/src/oscc.c
@@ -20,73 +20,86 @@ static int can_socket = -1;
 
 oscc_result_t oscc_open( unsigned int channel )
 {
-    oscc_result_t ret = OSCC_ERROR;
+    oscc_result_t result = OSCC_ERROR;
 
-    char buffer[16];
 
-    snprintf( buffer, 16, "can%1d", channel );
+    char can_string_buffer[16];
 
-    printf( "Opening CAN channel: %s\n", buffer );
+    snprintf( can_string_buffer, 16, "can%1d", channel );
 
-    ret = oscc_init_can( buffer );
+    printf( "Opening CAN channel: %s\n", can_string_buffer );
 
-    return ret;
+    result = oscc_init_can( can_string_buffer );
+
+
+    return result;
 }
 
 oscc_result_t oscc_close( unsigned int channel )
 {
-    oscc_result_t ret = OSCC_ERROR;
+    oscc_result_t result = OSCC_ERROR;
 
-    if( can_socket > 0 )
+
+    if( can_socket != -1 )
     {
         int result = close( can_socket );
 
         if ( result > 0 )
         {
-            ret = OSCC_OK;
+            result = OSCC_OK;
         }
     }
 
-    return ret;
+
+    return result;
 }
 
 oscc_result_t oscc_enable( void )
 {
-    oscc_result_t ret = oscc_enable_brakes( );
+    oscc_result_t result = OSCC_ERROR;
 
-    if (ret == OSCC_OK )
+
+    result = oscc_enable_brakes( );
+
+    if ( result == OSCC_OK )
     {
-        ret = oscc_enable_throttle( );
+        result = oscc_enable_throttle( );
 
-        if (ret == OSCC_OK )
+        if (result == OSCC_OK )
         {
-            ret = oscc_enable_steering( );
+            result = oscc_enable_steering( );
         }
     }
 
-    return ret;
+
+    return result;
 }
 
 oscc_result_t oscc_disable( void )
 {
-    oscc_result_t ret = oscc_disable_brakes( );
+    oscc_result_t result = OSCC_ERROR;
 
-    if ( ret == OSCC_OK )
+
+    result = oscc_disable_brakes( );
+
+    if ( result == OSCC_OK )
     {
-        ret = oscc_disable_throttle( );
+        result = oscc_disable_throttle( );
 
-        if ( ret == OSCC_OK )
+        if ( result == OSCC_OK )
         {
-            ret = oscc_disable_steering( );
+            result = oscc_disable_steering( );
         }
     }
 
-    return ret;
+
+    return result;
 }
 
 oscc_result_t oscc_publish_brake_position( double brake_position )
 {
-    oscc_result_t ret = OSCC_ERROR;
+    oscc_result_t result = OSCC_ERROR;
+
 
     oscc_brake_command_s brake_cmd =
     {
@@ -95,7 +108,7 @@ oscc_result_t oscc_publish_brake_position( double brake_position )
     };
 
 #if defined(KIA_SOUL)
-    const double clamped_position = (double) CONSTRAIN (
+    const double clamped_position = ( double ) CONSTRAIN (
             brake_position * MAXIMUM_BRAKE_COMMAND,
             MINIMUM_BRAKE_COMMAND,
             MAXIMUM_BRAKE_COMMAND );
@@ -125,24 +138,26 @@ oscc_result_t oscc_publish_brake_position( double brake_position )
         BRAKE_SPOOF_HIGH_SIGNAL_VOLTAGE_MAX);
 
 
-    uint16_t spoof_value_low = STEPS_PER_VOLT * spoof_voltage_low;
-    uint16_t spoof_value_high = STEPS_PER_VOLT * spoof_voltage_high;
+    const uint16_t spoof_value_low = STEPS_PER_VOLT * spoof_voltage_low;
+    const uint16_t spoof_value_high = STEPS_PER_VOLT * spoof_voltage_high;
 
     brake_cmd.spoof_value_low = spoof_value_low;
     brake_cmd.spoof_value_high = spoof_value_high;
 #endif
 
-    ret = oscc_can_write(
+    result = oscc_can_write(
         OSCC_BRAKE_COMMAND_CAN_ID,
         (void *) &brake_cmd,
         sizeof( brake_cmd ) );
 
-    return ret;
+
+    return result;
 }
 
 oscc_result_t oscc_publish_throttle_position( double throttle_position )
 {
-    oscc_result_t ret = OSCC_ERROR;
+    oscc_result_t result = OSCC_ERROR;
+
 
     oscc_throttle_command_s throttle_cmd =
     {
@@ -173,23 +188,25 @@ oscc_result_t oscc_publish_throttle_position( double throttle_position )
         THROTTLE_SPOOF_HIGH_SIGNAL_VOLTAGE_MAX);
 
 
-    uint16_t spoof_value_low = STEPS_PER_VOLT * spoof_voltage_low;
-    uint16_t spoof_value_high = STEPS_PER_VOLT * spoof_voltage_high;
+    const uint16_t spoof_value_low = STEPS_PER_VOLT * spoof_voltage_low;
+    const uint16_t spoof_value_high = STEPS_PER_VOLT * spoof_voltage_high;
 
     throttle_cmd.spoof_value_low = spoof_value_low;
     throttle_cmd.spoof_value_high = spoof_value_high;
 
-    ret = oscc_can_write(
+    result = oscc_can_write(
         OSCC_THROTTLE_COMMAND_CAN_ID,
         (void *)&throttle_cmd,
         sizeof(throttle_cmd));
 
-    return ret;
+
+    return result;
 }
 
 oscc_result_t oscc_publish_steering_torque( double torque )
 {
-    oscc_result_t ret = OSCC_ERROR;
+    oscc_result_t result = OSCC_ERROR;
+
 
     oscc_steering_command_s steering_cmd =
     {
@@ -220,83 +237,94 @@ oscc_result_t oscc_publish_steering_torque( double torque )
         STEERING_SPOOF_HIGH_SIGNAL_VOLTAGE_MAX);
 
 
-    uint16_t spoof_value_low = STEPS_PER_VOLT * spoof_voltage_low;
-    uint16_t spoof_value_high = STEPS_PER_VOLT * spoof_voltage_high;
+    const uint16_t spoof_value_low = STEPS_PER_VOLT * spoof_voltage_low;
+    const uint16_t spoof_value_high = STEPS_PER_VOLT * spoof_voltage_high;
 
     steering_cmd.spoof_value_low = spoof_value_low;
     steering_cmd.spoof_value_high = spoof_value_high;
 
-    ret = oscc_can_write(
+    result = oscc_can_write(
         OSCC_STEERING_COMMAND_CAN_ID,
         (void *)&steering_cmd,
         sizeof(steering_cmd));
 
-    return ret;
+
+    return result;
 }
 
 oscc_result_t oscc_subscribe_to_brake_reports( void (*callback)(oscc_brake_report_s *report) )
 {
-    oscc_result_t ret = OSCC_ERROR;
+    oscc_result_t result = OSCC_ERROR;
+
 
     if ( callback != NULL )
     {
         brake_report_callback = callback;
-        ret = OSCC_OK;
+        result = OSCC_OK;
     }
 
-    return ret;
+
+    return result;
 }
 
 oscc_result_t oscc_subscribe_to_throttle_reports( void (*callback)(oscc_throttle_report_s *report) )
 {
-    oscc_result_t ret = OSCC_ERROR;
+    oscc_result_t result = OSCC_ERROR;
+
 
     if ( callback != NULL )
     {
         throttle_report_callback = callback;
-        ret = OSCC_OK;
+        result = OSCC_OK;
     }
 
-    return ret;
+
+    return result;
 }
 
 oscc_result_t oscc_subscribe_to_steering_reports( void (*callback)(oscc_steering_report_s *report))
 {
-    oscc_result_t ret = OSCC_ERROR;
+    oscc_result_t result = OSCC_ERROR;
+
 
     if ( callback != NULL )
     {
         steering_report_callback = callback;
-        ret = OSCC_OK;
+        result = OSCC_OK;
     }
 
-    return ret;
+
+    return result;
 }
 
 oscc_result_t oscc_subscribe_to_fault_reports( void (*callback)(oscc_fault_report_s *report))
 {
-    oscc_result_t ret = OSCC_ERROR;
+    oscc_result_t result = OSCC_ERROR;
+
 
     if ( callback != NULL )
     {
         fault_report_callback = callback;
-        ret = OSCC_OK;
+        result = OSCC_OK;
     }
 
-    return ret;
+
+    return result;
 }
 
 oscc_result_t oscc_subscribe_to_obd_messages( void (*callback)(struct can_frame *frame))
 {
-    oscc_result_t ret = OSCC_ERROR;
+    oscc_result_t result = OSCC_ERROR;
+
 
     if ( callback != NULL )
     {
         obd_frame_callback = callback;
-        ret = OSCC_OK;
+        result = OSCC_OK;
     }
 
-    return ret;
+
+    return result;
 }
 
 
@@ -305,7 +333,8 @@ oscc_result_t oscc_subscribe_to_obd_messages( void (*callback)(struct can_frame 
 /* Internal */
 oscc_result_t oscc_enable_brakes( void )
 {
-    oscc_result_t ret = OSCC_ERROR;
+    oscc_result_t result = OSCC_ERROR;
+
 
     oscc_brake_enable_s brake_enable =
     {
@@ -313,17 +342,19 @@ oscc_result_t oscc_enable_brakes( void )
         .magic[1] = ( uint8_t ) OSCC_MAGIC_BYTE_1
     };
 
-    ret = oscc_can_write(
+    result = oscc_can_write(
         OSCC_BRAKE_ENABLE_CAN_ID,
         (void *) &brake_enable,
-        sizeof( brake_enable ) );
+        sizeof(brake_enable) );
 
-    return ret;
+
+    return result;
 }
 
 oscc_result_t oscc_enable_throttle( void )
 {
-    oscc_result_t ret = OSCC_ERROR;
+    oscc_result_t result = OSCC_ERROR;
+
 
     oscc_throttle_enable_s throttle_enable =
     {
@@ -331,17 +362,19 @@ oscc_result_t oscc_enable_throttle( void )
         .magic[1] = ( uint8_t ) OSCC_MAGIC_BYTE_1
     };
 
-    ret = oscc_can_write(
+    result = oscc_can_write(
         OSCC_THROTTLE_ENABLE_CAN_ID,
         (void *) &throttle_enable,
-        sizeof( throttle_enable ) );
+        sizeof(throttle_enable) );
 
-    return ret;
+
+    return result;
 }
 
 oscc_result_t oscc_enable_steering( void )
 {
-    oscc_result_t ret = OSCC_ERROR;
+    oscc_result_t result = OSCC_ERROR;
+
 
     oscc_steering_enable_s steering_enable =
     {
@@ -349,17 +382,19 @@ oscc_result_t oscc_enable_steering( void )
         .magic[1] = ( uint8_t ) OSCC_MAGIC_BYTE_1
     };
 
-    ret = oscc_can_write(
+    result = oscc_can_write(
         OSCC_STEERING_ENABLE_CAN_ID,
         (void *) &steering_enable,
-        sizeof( steering_enable ) );
+        sizeof(steering_enable) );
 
-    return ret;
+
+    return result;
 }
 
 oscc_result_t oscc_disable_brakes( void )
 {
-    oscc_result_t ret = OSCC_ERROR;
+    oscc_result_t result = OSCC_ERROR;
+
 
     oscc_brake_disable_s brake_disable =
     {
@@ -367,17 +402,19 @@ oscc_result_t oscc_disable_brakes( void )
         .magic[1] = ( uint8_t ) OSCC_MAGIC_BYTE_1
     };
 
-    ret = oscc_can_write(
+    result = oscc_can_write(
         OSCC_BRAKE_DISABLE_CAN_ID,
         (void *) &brake_disable,
-        sizeof( brake_disable ) );
+        sizeof(brake_disable) );
 
-    return ret;
+
+    return result;
 }
 
 oscc_result_t oscc_disable_throttle( void )
 {
-    oscc_result_t ret = OSCC_ERROR;
+    oscc_result_t result = OSCC_ERROR;
+
 
     oscc_throttle_disable_s throttle_disable =
     {
@@ -385,17 +422,19 @@ oscc_result_t oscc_disable_throttle( void )
         .magic[1] = ( uint8_t ) OSCC_MAGIC_BYTE_1
     };
 
-    ret = oscc_can_write(
+    result = oscc_can_write(
         OSCC_THROTTLE_DISABLE_CAN_ID,
         (void *) &throttle_disable,
-        sizeof( throttle_disable ) );
+        sizeof(throttle_disable) );
 
-    return ret;
+
+    return result;
 }
 
 oscc_result_t oscc_disable_steering( void )
 {
-    oscc_result_t ret = OSCC_ERROR;
+    oscc_result_t result = OSCC_ERROR;
+
 
     oscc_steering_disable_s steering_disable =
     {
@@ -403,31 +442,32 @@ oscc_result_t oscc_disable_steering( void )
         .magic[1] = ( uint8_t ) OSCC_MAGIC_BYTE_1
     };
 
-    ret = oscc_can_write(
+    result = oscc_can_write(
         OSCC_STEERING_DISABLE_CAN_ID,
         (void *) &steering_disable,
-        sizeof( steering_disable ) );
+        sizeof(steering_disable) );
 
-    return ret;
+
+    return result;
 }
 
 void oscc_update_status( )
 {
     struct can_frame rx_frame;
 
-    if ( can_socket > 0 )
+    if ( can_socket != -1 )
     {
-        int result = read( can_socket, &rx_frame, CAN_MTU );
+        int ret = read( can_socket, &rx_frame, CAN_MTU );
 
-        while ( result > 0 )
+        while ( ret > 0 )
         {
             if ( (rx_frame.data[0] == OSCC_MAGIC_BYTE_0)
-                && (rx_frame.data[1] = OSCC_MAGIC_BYTE_1) )
+                && (rx_frame.data[1] == OSCC_MAGIC_BYTE_1) )
             {
                 if ( rx_frame.can_id == OSCC_STEERING_REPORT_CAN_ID )
                 {
                     oscc_steering_report_s *steering_report =
-                        (oscc_steering_report_s *)rx_frame.data;
+                        ( oscc_steering_report_s* ) rx_frame.data;
 
                     if ( steering_report_callback != NULL )
                     {
@@ -437,7 +477,7 @@ void oscc_update_status( )
                 else if ( rx_frame.can_id == OSCC_THROTTLE_REPORT_CAN_ID )
                 {
                     oscc_throttle_report_s *throttle_report =
-                        ( oscc_throttle_report_s *)rx_frame.data;
+                        ( oscc_throttle_report_s* ) rx_frame.data;
 
                     if ( throttle_report_callback != NULL )
                     {
@@ -447,7 +487,7 @@ void oscc_update_status( )
                 else if ( rx_frame.can_id == OSCC_BRAKE_REPORT_CAN_ID )
                 {
                     oscc_brake_report_s *brake_report =
-                        ( oscc_brake_report_s *)rx_frame.data;
+                        ( oscc_brake_report_s* ) rx_frame.data;
 
                     if ( brake_report_callback != NULL )
                     {
@@ -457,7 +497,7 @@ void oscc_update_status( )
                 else if ( rx_frame.can_id == OSCC_FAULT_REPORT_CAN_ID )
                 {
                     oscc_fault_report_s *fault_report =
-                        ( oscc_fault_report_s *)rx_frame.data;
+                        ( oscc_fault_report_s* ) rx_frame.data;
 
                     if ( fault_report_callback != NULL )
                     {
@@ -473,16 +513,17 @@ void oscc_update_status( )
                 }
             }
 
-            result = read( can_socket, &rx_frame, CAN_MTU );
+            ret = read( can_socket, &rx_frame, CAN_MTU );
         }
     }
 }
 
 oscc_result_t oscc_can_write( long id, void *msg, unsigned int dlc )
 {
-    oscc_result_t ret = OSCC_ERROR;
+    oscc_result_t result = OSCC_ERROR;
 
-    if ( can_socket > 0 )
+
+    if ( can_socket != -1 )
     {
         struct can_frame tx_frame;
 
@@ -490,11 +531,11 @@ oscc_result_t oscc_can_write( long id, void *msg, unsigned int dlc )
         tx_frame.can_dlc = dlc;
         memcpy( tx_frame.data, msg, dlc );
 
-        int result = write( can_socket, &tx_frame, sizeof(tx_frame) );
+        int ret = write( can_socket, &tx_frame, sizeof(tx_frame) );
 
-        if ( result > 0 )
+        if ( ret > 0 )
         {
-            ret = OSCC_OK;
+            result = OSCC_OK;
         }
         else
         {
@@ -502,33 +543,48 @@ oscc_result_t oscc_can_write( long id, void *msg, unsigned int dlc )
         }
     }
 
-    return ret;
+
+    return result;
 }
 
 oscc_result_t oscc_async_enable( int socket )
 {
-    oscc_result_t ret = OSCC_ERROR;
+    oscc_result_t result = OSCC_ERROR;
 
-    ret = fcntl( socket, F_SETOWN, getpid( ) );
+
+    int ret = fcntl( socket, F_SETOWN, getpid( ) );
 
     if ( ret < 0 )
     {
         printf( "Setting owner process of socket failed: %s\n", strerror(errno) );
     }
-
-    ret = fcntl( socket, F_SETFL, FASYNC | O_NONBLOCK );
-
-    if ( ret < 0 )
+    else
     {
-        printf( "Setting nonblocking asynchronous socket I/O failed: %s\n", strerror(errno) );
+        result = OSCC_OK;
     }
 
-    return ret;
+
+    if ( result == OSCC_OK )
+    {
+        ret = fcntl( socket, F_SETFL, FASYNC | O_NONBLOCK );
+
+        if ( ret < 0 )
+        {
+            printf( "Setting nonblocking asynchronous socket I/O failed: %s\n", strerror(errno) );
+
+            result = OSCC_ERROR;
+        }
+    }
+
+
+    return result;
 }
 
 oscc_result_t oscc_init_can( const char *can_channel )
 {
-    int ret = OSCC_OK;
+    int result = OSCC_ERROR;
+    int ret = -1;
+
 
     struct sigaction sig;
 
@@ -538,65 +594,69 @@ oscc_result_t oscc_init_can( const char *can_channel )
     sig.sa_handler = oscc_update_status;
     sigaction( SIGIO, &sig, NULL );
 
-    int s = socket( PF_CAN, SOCK_RAW, CAN_RAW );
+    int sock = socket( PF_CAN, SOCK_RAW, CAN_RAW );
 
-    if ( s < 0 )
+    if ( sock < 0 )
     {
         printf( "Opening CAN socket failed: %s\n", strerror(errno) );
-
-        ret = OSCC_ERROR;
+    }
+    else
+    {
+        result = OSCC_OK;
     }
 
-    int status;
 
     struct ifreq ifr;
 
-    if ( ret != OSCC_ERROR )
+    if ( result == OSCC_OK )
     {
         strncpy( ifr.ifr_name, can_channel, IFNAMSIZ );
 
-        status = ioctl( s, SIOCGIFINDEX, &ifr );
+        ret = ioctl( sock, SIOCGIFINDEX, &ifr );
 
-        if ( status < 0 )
+        if ( ret < 0 )
         {
             printf( "Finding CAN index failed: %s\n", strerror(errno) );
 
-            ret = OSCC_ERROR;
+            result = OSCC_ERROR;
         }
     }
 
-    if ( ret != OSCC_ERROR )
+
+    if ( result == OSCC_OK )
     {
         struct sockaddr_can can_address;
 
         can_address.can_family = AF_CAN;
         can_address.can_ifindex = ifr.ifr_ifindex;
 
-        status = bind( s,
+        ret = bind( sock,
                       (struct sockaddr *)&can_address,
                       sizeof(can_address));
 
-        if ( status < 0 )
+        if ( ret < 0 )
         {
             printf( "Socket binding failed: %s\n", strerror(errno) );
 
-            ret = OSCC_ERROR;
+            result = OSCC_ERROR;
         }
     }
 
-    if ( ret != OSCC_ERROR )
-    {
-        status = oscc_async_enable( s );
 
-        if ( status != OSCC_OK )
+    if ( result == OSCC_OK )
+    {
+        ret = oscc_async_enable( sock );
+
+        if ( ret != OSCC_OK )
         {
             printf( "Enabling asynchronous socket I/O failed\n" );
 
-            ret = OSCC_ERROR;
+            result = OSCC_ERROR;
         }
     }
 
-    if ( ret != OSCC_ERROR )
+
+    if ( result == OSCC_OK )
     {
         /* all prior checks will pass even if a valid interface has not been
            set up - attempt to write an empty CAN frame to the interface to see
@@ -607,19 +667,20 @@ oscc_result_t oscc_init_can( const char *can_channel )
         tx_frame.can_dlc = 8;
         memset( tx_frame.data, 0, sizeof(tx_frame.data) );
 
-        int bytes_written = write( s, &tx_frame, sizeof(tx_frame) );
+        int bytes_written = write( sock, &tx_frame, sizeof(tx_frame) );
 
         if ( bytes_written < 0 )
         {
             printf( "Failed to write test frame to %s: %s\n", can_channel, strerror(errno) );
 
-            ret = OSCC_ERROR;
+            result = OSCC_ERROR;
         }
         else
         {
-            can_socket = s;
+            can_socket = sock;
         }
     }
 
-    return ret;
+
+    return result;
 }

--- a/api/src/oscc.c
+++ b/api/src/oscc.c
@@ -1,24 +1,24 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/can.h>
+#include <net/if.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
-#include <fcntl.h>
-#include <sys/types.h>
 #include <sys/ioctl.h>
-#include <net/if.h>
 #include <sys/socket.h>
-#include <linux/can.h>
-#include <errno.h>
-#include <signal.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 #include "can_protocols/brake_can_protocol.h"
 #include "can_protocols/fault_can_protocol.h"
-#include "can_protocols/throttle_can_protocol.h"
 #include "can_protocols/steering_can_protocol.h"
-#include "vehicles.h"
+#include "can_protocols/throttle_can_protocol.h"
 #include "dtc.h"
 #include "oscc.h"
 #include "internal/oscc.h"
+#include "vehicles.h"
 
 
 static int can_socket = -1;

--- a/api/src/oscc.c
+++ b/api/src/oscc.c
@@ -25,7 +25,7 @@ oscc_result_t oscc_open( unsigned int channel )
 
     char can_string_buffer[16];
 
-    snprintf( can_string_buffer, 16, "can%1u", channel );
+    snprintf( can_string_buffer, 16, "can%u", channel );
 
     printf( "Opening CAN channel: %s\n", can_string_buffer );
 

--- a/api/src/oscc.c
+++ b/api/src/oscc.c
@@ -25,7 +25,7 @@ oscc_result_t oscc_open( unsigned int channel )
 
     char can_string_buffer[16];
 
-    snprintf( can_string_buffer, 16, "can%1d", channel );
+    snprintf( can_string_buffer, 16, "can%1u", channel );
 
     printf( "Opening CAN channel: %s\n", can_string_buffer );
 

--- a/api/src/oscc.c
+++ b/api/src/oscc.c
@@ -11,14 +11,8 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#include "can_protocols/brake_can_protocol.h"
-#include "can_protocols/fault_can_protocol.h"
-#include "can_protocols/steering_can_protocol.h"
-#include "can_protocols/throttle_can_protocol.h"
-#include "dtc.h"
 #include "oscc.h"
 #include "internal/oscc.h"
-#include "vehicles.h"
 
 
 static int can_socket = -1;

--- a/api/src/oscc.c
+++ b/api/src/oscc.c
@@ -634,9 +634,10 @@ oscc_result_t oscc_init_can( const char *can_channel )
         can_address.can_family = AF_CAN;
         can_address.can_ifindex = ifr.ifr_ifindex;
 
-        ret = bind( sock,
-                      (struct sockaddr *)&can_address,
-                      sizeof(can_address) );
+        ret = bind(
+            sock,
+            (struct sockaddr *) &can_address,
+            sizeof(can_address) );
 
         if ( ret < 0 )
         {

--- a/api/src/oscc.c
+++ b/api/src/oscc.c
@@ -148,7 +148,7 @@ oscc_result_t oscc_publish_brake_position( double brake_position )
     result = oscc_can_write(
         OSCC_BRAKE_COMMAND_CAN_ID,
         (void *) &brake_cmd,
-        sizeof( brake_cmd ) );
+        sizeof(brake_cmd) );
 
 
     return result;
@@ -196,8 +196,8 @@ oscc_result_t oscc_publish_throttle_position( double throttle_position )
 
     result = oscc_can_write(
         OSCC_THROTTLE_COMMAND_CAN_ID,
-        (void *)&throttle_cmd,
-        sizeof(throttle_cmd));
+        (void *) &throttle_cmd,
+        sizeof(throttle_cmd) );
 
 
     return result;
@@ -245,8 +245,8 @@ oscc_result_t oscc_publish_steering_torque( double torque )
 
     result = oscc_can_write(
         OSCC_STEERING_COMMAND_CAN_ID,
-        (void *)&steering_cmd,
-        sizeof(steering_cmd));
+        (void *) &steering_cmd,
+        sizeof(steering_cmd) );
 
 
     return result;
@@ -636,7 +636,7 @@ oscc_result_t oscc_init_can( const char *can_channel )
 
         ret = bind( sock,
                       (struct sockaddr *)&can_address,
-                      sizeof(can_address));
+                      sizeof(can_address) );
 
         if ( ret < 0 )
         {

--- a/firmware/brake/kia_soul_ev/include/globals.h
+++ b/firmware/brake/kia_soul_ev/include/globals.h
@@ -9,10 +9,9 @@
 #define _OSCC_BRAKE_GLOBALS_H_
 
 
+#include "brake_control.h"
 #include "DAC_MCP49xx.h"
 #include "mcp_can.h"
-
-#include "brake_control.h"
 
 
 /*

--- a/firmware/brake/kia_soul_ev/src/brake_control.cpp
+++ b/firmware/brake/kia_soul_ev/src/brake_control.cpp
@@ -6,15 +6,15 @@
 
 #include <Arduino.h>
 #include <stdint.h>
-#include "debug.h"
-#include "oscc_dac.h"
-#include "can_protocols/brake_can_protocol.h"
-#include "dtc.h"
-#include "vehicles.h"
 
-#include "communications.h"
+#include "can_protocols/brake_can_protocol.h"
 #include "brake_control.h"
+#include "communications.h"
+#include "debug.h"
+#include "dtc.h"
 #include "globals.h"
+#include "oscc_dac.h"
+#include "vehicles.h"
 
 
 /*

--- a/firmware/brake/kia_soul_ev/src/communications.cpp
+++ b/firmware/brake/kia_soul_ev/src/communications.cpp
@@ -4,15 +4,16 @@
  */
 
 
+#include <stdint.h>
+
+#include "can_protocols/brake_can_protocol.h"
+#include "can_protocols/fault_can_protocol.h"
+#include "brake_control.h"
+#include "communications.h"
+#include "debug.h"
+#include "globals.h"
 #include "mcp_can.h"
 #include "oscc_can.h"
-#include "can_protocols/fault_can_protocol.h"
-#include "can_protocols/brake_can_protocol.h"
-#include "debug.h"
-
-#include "globals.h"
-#include "communications.h"
-#include "brake_control.h"
 
 
 static void process_rx_frame(

--- a/firmware/brake/kia_soul_ev/src/init.cpp
+++ b/firmware/brake/kia_soul_ev/src/init.cpp
@@ -5,14 +5,14 @@
 
 
 #include <Arduino.h>
-#include "oscc_serial.h"
-#include "oscc_can.h"
-#include "can_protocols/brake_can_protocol.h"
-#include "debug.h"
 
-#include "globals.h"
+#include "can_protocols/brake_can_protocol.h"
 #include "communications.h"
+#include "debug.h"
+#include "globals.h"
 #include "init.h"
+#include "oscc_can.h"
+#include "oscc_serial.h"
 
 
 void init_globals( void )

--- a/firmware/brake/kia_soul_ev/src/main.cpp
+++ b/firmware/brake/kia_soul_ev/src/main.cpp
@@ -5,12 +5,12 @@
 
 
 #include "arduino_init.h"
+#include "brake_control.h"
+#include "communications.h"
 #include "debug.h"
-
 #include "init.h"
 #include "timers.h"
-#include "communications.h"
-#include "brake_control.h"
+
 
 int main( void )
 {

--- a/firmware/brake/kia_soul_ev/src/timers.cpp
+++ b/firmware/brake/kia_soul_ev/src/timers.cpp
@@ -4,13 +4,14 @@
  */
 
 
-#include "can_protocols/brake_can_protocol.h"
-#include "oscc_timer.h"
+#include <Arduino.h>
 
-#include "timers.h"
-#include "globals.h"
-#include "communications.h"
 #include "brake_control.h"
+#include "can_protocols/brake_can_protocol.h"
+#include "communications.h"
+#include "globals.h"
+#include "oscc_timer.h"
+#include "timers.h"
 
 
 /*

--- a/firmware/brake/kia_soul_petrol/include/globals.h
+++ b/firmware/brake/kia_soul_petrol/include/globals.h
@@ -9,10 +9,9 @@
 #define _OSCC_BRAKE_GLOBALS_H_
 
 
+#include "brake_control.h"
 #include "mcp_can.h"
 #include "oscc_pid.h"
-
-#include "brake_control.h"
 
 
 /*

--- a/firmware/brake/kia_soul_petrol/src/accumulator.cpp
+++ b/firmware/brake/kia_soul_petrol/src/accumulator.cpp
@@ -5,12 +5,12 @@
 
 
 #include <Arduino.h>
-#include "vehicles.h"
 
-#include "globals.h"
 #include "accumulator.h"
-#include "helper.h"
 #include "debug.h"
+#include "globals.h"
+#include "helper.h"
+#include "vehicles.h"
 
 
 void accumulator_init( void )

--- a/firmware/brake/kia_soul_petrol/src/brake_control.cpp
+++ b/firmware/brake/kia_soul_petrol/src/brake_control.cpp
@@ -4,18 +4,20 @@
  */
 
 
-#include "debug.h"
-#include "oscc_pid.h"
-#include "dtc.h"
-#include "can_protocols/brake_can_protocol.h"
-#include "vehicles.h"
+#include <Arduino.h>
+#include <stdint.h>
 
-#include "globals.h"
 #include "accumulator.h"
 #include "brake_control.h"
+#include "can_protocols/brake_can_protocol.h"
 #include "communications.h"
-#include "master_cylinder.h"
+#include "debug.h"
+#include "dtc.h"
+#include "globals.h"
 #include "helper.h"
+#include "master_cylinder.h"
+#include "oscc_pid.h"
+#include "vehicles.h"
 
 
 /*

--- a/firmware/brake/kia_soul_petrol/src/communications.cpp
+++ b/firmware/brake/kia_soul_petrol/src/communications.cpp
@@ -4,15 +4,17 @@
  */
 
 
-#include "mcp_can.h"
+#include <Arduino.h>
+#include <stdint.h>
+
+#include "brake_control.h"
 #include "can_protocols/brake_can_protocol.h"
 #include "can_protocols/fault_can_protocol.h"
-#include "oscc_can.h"
-#include "debug.h"
-
-#include "globals.h"
 #include "communications.h"
-#include "brake_control.h"
+#include "debug.h"
+#include "globals.h"
+#include "mcp_can.h"
+#include "oscc_can.h"
 
 
 static void process_rx_frame(

--- a/firmware/brake/kia_soul_petrol/src/helper.cpp
+++ b/firmware/brake/kia_soul_petrol/src/helper.cpp
@@ -4,12 +4,9 @@
  */
 
 
-#include <stdint.h>
-#include <stdlib.h>
-#include "vehicles.h"
-
 #include "globals.h"
 #include "helper.h"
+#include "vehicles.h"
 
 
 float interpolate(

--- a/firmware/brake/kia_soul_petrol/src/helper.cpp
+++ b/firmware/brake/kia_soul_petrol/src/helper.cpp
@@ -4,6 +4,8 @@
  */
 
 
+#include <stdlib.h>
+
 #include "globals.h"
 #include "helper.h"
 #include "vehicles.h"

--- a/firmware/brake/kia_soul_petrol/src/init.cpp
+++ b/firmware/brake/kia_soul_petrol/src/init.cpp
@@ -5,19 +5,19 @@
 
 
 #include <Arduino.h>
-#include "oscc_serial.h"
-#include "oscc_can.h"
-#include "debug.h"
-#include "oscc_timer.h"
-#include "can_protocols/brake_can_protocol.h"
-#include "vehicles.h"
 
+#include "accumulator.h"
+#include "brake_control.h"
+#include "can_protocols/brake_can_protocol.h"
+#include "communications.h"
+#include "debug.h"
 #include "globals.h"
 #include "init.h"
-#include "communications.h"
-#include "accumulator.h"
 #include "master_cylinder.h"
-#include "brake_control.h"
+#include "oscc_can.h"
+#include "oscc_serial.h"
+#include "oscc_timer.h"
+#include "vehicles.h"
 
 
 void init_globals( void )

--- a/firmware/brake/kia_soul_petrol/src/main.cpp
+++ b/firmware/brake/kia_soul_petrol/src/main.cpp
@@ -4,14 +4,13 @@
  */
 
 
-#include "arduino_init.h"
-
-#include "debug.h"
 #include "accumulator.h"
+#include "arduino_init.h"
 #include "brake_control.h"
 #include "communications.h"
-#include "timers.h"
+#include "debug.h"
 #include "init.h"
+#include "timers.h"
 
 
 int main( void )

--- a/firmware/brake/kia_soul_petrol/src/master_cylinder.cpp
+++ b/firmware/brake/kia_soul_petrol/src/master_cylinder.cpp
@@ -5,8 +5,8 @@
 
 
 #include <Arduino.h>
-#include "debug.h"
 
+#include "debug.h"
 #include "globals.h"
 #include "helper.h"
 #include "master_cylinder.h"

--- a/firmware/brake/kia_soul_petrol/src/timers.cpp
+++ b/firmware/brake/kia_soul_petrol/src/timers.cpp
@@ -4,13 +4,14 @@
  */
 
 
-#include "can_protocols/brake_can_protocol.h"
-#include "oscc_timer.h"
+#include <Arduino.h>
 
-#include "timers.h"
 #include "globals.h"
-#include "communications.h"
 #include "brake_control.h"
+#include "can_protocols/brake_can_protocol.h"
+#include "communications.h"
+#include "oscc_timer.h"
+#include "timers.h"
 
 
 /*

--- a/firmware/can_gateway/src/communications.cpp
+++ b/firmware/can_gateway/src/communications.cpp
@@ -4,12 +4,11 @@
  */
 
 
+#include "communications.h"
+#include "globals.h"
 #include "mcp_can.h"
 #include "oscc_can.h"
 #include "vehicles.h"
-
-#include "globals.h"
-#include "communications.h"
 
 
 void republish_obd_frames_to_control_can_bus( void )

--- a/firmware/can_gateway/src/init.cpp
+++ b/firmware/can_gateway/src/init.cpp
@@ -4,12 +4,11 @@
  */
 
 
-#include "oscc_serial.h"
-#include "oscc_can.h"
 #include "debug.h"
-
 #include "globals.h"
 #include "init.h"
+#include "oscc_can.h"
+#include "oscc_serial.h"
 
 
 void init_communication_interfaces( void )

--- a/firmware/can_gateway/src/main.cpp
+++ b/firmware/can_gateway/src/main.cpp
@@ -5,11 +5,11 @@
 
 
 #include <avr/wdt.h>
-#include "arduino_init.h"
-#include "debug.h"
 
-#include "init.h"
+#include "arduino_init.h"
 #include "communications.h"
+#include "debug.h"
+#include "init.h"
 
 
 int main( void )

--- a/firmware/common/libs/can/oscc_can.cpp
+++ b/firmware/common/libs/can/oscc_can.cpp
@@ -1,8 +1,13 @@
+/**
+ * @file oscc_can.cpp
+ *
+ */
+
+
 #include <string.h>
 
-#include "mcp_can.h"
 #include "debug.h"
-
+#include "mcp_can.h"
 #include "oscc_can.h"
 
 

--- a/firmware/common/libs/can/oscc_can.h
+++ b/firmware/common/libs/can/oscc_can.h
@@ -10,6 +10,7 @@
 
 
 #include <stdint.h>
+
 #include "mcp_can.h"
 
 

--- a/firmware/common/libs/dac/oscc_dac.cpp
+++ b/firmware/common/libs/dac/oscc_dac.cpp
@@ -1,3 +1,9 @@
+/**
+ * @file oscc_dac.cpp
+ *
+ */
+
+
 #include <Arduino.h>
 
 #include "oscc_dac.h"

--- a/firmware/common/libs/dac/oscc_dac.h
+++ b/firmware/common/libs/dac/oscc_dac.h
@@ -1,6 +1,6 @@
 /**
- * @file helper.h
- * @brief Helper functions.
+ * @file oscc_dac.h
+ * @brief OSCC DAC interface.
  *
  */
 
@@ -10,6 +10,7 @@
 
 
 #include "DAC_MCP49xx.h"
+
 
 /*
  * @brief Number of bits to shift to go from a 10-bit value to a 12-bit value.

--- a/firmware/common/libs/serial/oscc_serial.cpp
+++ b/firmware/common/libs/serial/oscc_serial.cpp
@@ -1,10 +1,11 @@
 /**
- * @file serial.h
+ * @file oscc_serial.cpp
  *
  */
 
 
 #include <Arduino.h>
+
 #include "debug.h"
 #include "oscc_serial.h"
 

--- a/firmware/common/libs/serial/oscc_serial.h
+++ b/firmware/common/libs/serial/oscc_serial.h
@@ -1,5 +1,5 @@
 /**
- * @file serial.h
+ * @file oscc_serial.h
  * @brief Serial interface.
  *
  */

--- a/firmware/common/libs/timer/oscc_timer.cpp
+++ b/firmware/common/libs/timer/oscc_timer.cpp
@@ -4,7 +4,8 @@
  */
 
 
-#include "Arduino.h"
+#include <Arduino.h>
+
 #include "oscc_timer.h"
 
 

--- a/firmware/steering/include/globals.h
+++ b/firmware/steering/include/globals.h
@@ -11,7 +11,6 @@
 
 #include "DAC_MCP49xx.h"
 #include "mcp_can.h"
-
 #include "steering_control.h"
 
 

--- a/firmware/steering/src/communications.cpp
+++ b/firmware/steering/src/communications.cpp
@@ -4,15 +4,16 @@
  */
 
 
-#include "mcp_can.h"
-#include "oscc_can.h"
+#include <stdint.h>
+
 #include "can_protocols/fault_can_protocol.h"
 #include "can_protocols/steering_can_protocol.h"
-#include "debug.h"
-
-#include "globals.h"
 #include "communications.h"
+#include "debug.h"
+#include "globals.h"
+#include "mcp_can.h"
 #include "steering_control.h"
+#include "oscc_can.h"
 
 
 static void process_rx_frame(

--- a/firmware/steering/src/init.cpp
+++ b/firmware/steering/src/init.cpp
@@ -5,14 +5,14 @@
 
 
 #include <Arduino.h>
-#include "oscc_serial.h"
-#include "oscc_can.h"
-#include "can_protocols/steering_can_protocol.h"
-#include "debug.h"
 
-#include "globals.h"
+#include "can_protocols/steering_can_protocol.h"
 #include "communications.h"
+#include "debug.h"
+#include "globals.h"
 #include "init.h"
+#include "oscc_can.h"
+#include "oscc_serial.h"
 
 
 void init_globals( void )

--- a/firmware/steering/src/main.cpp
+++ b/firmware/steering/src/main.cpp
@@ -5,12 +5,11 @@
 
 
 #include "arduino_init.h"
-#include "debug.h"
-
-#include "init.h"
-#include "timers.h"
 #include "communications.h"
+#include "debug.h"
+#include "init.h"
 #include "steering_control.h"
+#include "timers.h"
 
 
 int main( void )

--- a/firmware/steering/src/steering_control.cpp
+++ b/firmware/steering/src/steering_control.cpp
@@ -5,17 +5,17 @@
 
 
 #include <Arduino.h>
-#include <stdlib.h>
 #include <stdint.h>
-#include "debug.h"
-#include "oscc_dac.h"
-#include "can_protocols/steering_can_protocol.h"
-#include "dtc.h"
-#include "vehicles.h"
+#include <stdlib.h>
 
+#include "can_protocols/steering_can_protocol.h"
 #include "communications.h"
-#include "steering_control.h"
+#include "debug.h"
+#include "dtc.h"
 #include "globals.h"
+#include "oscc_dac.h"
+#include "steering_control.h"
+#include "vehicles.h"
 
 
 /*
@@ -25,6 +25,7 @@
  */
 #define SENSOR_VALIDITY_CHECK_FAULT_COUNT ( 4 )
 
+
 static void read_torque_sensor(
     steering_torque_s * value );
 
@@ -33,7 +34,9 @@ static float exponential_moving_average(
     const float input,
     const float average );
 
+
 static uint16_t filtered_diff = 0;
+
 
 void check_for_operator_override( void )
 {

--- a/firmware/steering/src/timers.cpp
+++ b/firmware/steering/src/timers.cpp
@@ -4,13 +4,14 @@
  */
 
 
-#include "can_protocols/steering_can_protocol.h"
-#include "oscc_timer.h"
+#include <Arduino.h>
 
-#include "timers.h"
-#include "globals.h"
+#include "can_protocols/steering_can_protocol.h"
 #include "communications.h"
+#include "globals.h"
+#include "oscc_timer.h"
 #include "steering_control.h"
+#include "timers.h"
 
 
 /*

--- a/firmware/throttle/include/globals.h
+++ b/firmware/throttle/include/globals.h
@@ -11,7 +11,6 @@
 
 #include "DAC_MCP49xx.h"
 #include "mcp_can.h"
-
 #include "throttle_control.h"
 
 

--- a/firmware/throttle/src/communications.cpp
+++ b/firmware/throttle/src/communications.cpp
@@ -4,14 +4,15 @@
  */
 
 
-#include "mcp_can.h"
-#include "oscc_can.h"
+#include <stdint.h>
+
 #include "can_protocols/fault_can_protocol.h"
 #include "can_protocols/throttle_can_protocol.h"
-#include "debug.h"
-
-#include "globals.h"
 #include "communications.h"
+#include "debug.h"
+#include "globals.h"
+#include "mcp_can.h"
+#include "oscc_can.h"
 #include "throttle_control.h"
 
 

--- a/firmware/throttle/src/init.cpp
+++ b/firmware/throttle/src/init.cpp
@@ -5,21 +5,21 @@
 
 
 #include <Arduino.h>
-#include "oscc_serial.h"
-#include "oscc_can.h"
-#include "can_protocols/throttle_can_protocol.h"
-#include "debug.h"
 
-#include "globals.h"
+#include "can_protocols/throttle_can_protocol.h"
 #include "communications.h"
+#include "debug.h"
+#include "globals.h"
 #include "init.h"
+#include "oscc_can.h"
+#include "oscc_serial.h"
 
 
 void init_globals( void )
 {
-   g_throttle_control_state.enabled = false;
-   g_throttle_control_state.operator_override = false;
-   g_throttle_control_state.dtcs = 0;
+    g_throttle_control_state.enabled = false;
+    g_throttle_control_state.operator_override = false;
+    g_throttle_control_state.dtcs = 0;
 
     g_throttle_command_timeout = false;
 }

--- a/firmware/throttle/src/main.cpp
+++ b/firmware/throttle/src/main.cpp
@@ -5,12 +5,12 @@
 
 
 #include "arduino_init.h"
+#include "communications.h"
 #include "debug.h"
-
 #include "init.h"
 #include "timers.h"
-#include "communications.h"
 #include "throttle_control.h"
+
 
 int main( void )
 {

--- a/firmware/throttle/src/throttle_control.cpp
+++ b/firmware/throttle/src/throttle_control.cpp
@@ -6,15 +6,15 @@
 
 #include <Arduino.h>
 #include <stdint.h>
-#include "debug.h"
-#include "oscc_dac.h"
-#include "can_protocols/throttle_can_protocol.h"
-#include "dtc.h"
-#include "vehicles.h"
 
+#include "can_protocols/throttle_can_protocol.h"
 #include "communications.h"
-#include "throttle_control.h"
+#include "debug.h"
+#include "dtc.h"
 #include "globals.h"
+#include "oscc_dac.h"
+#include "throttle_control.h"
+#include "vehicles.h"
 
 
 /*

--- a/firmware/throttle/src/timers.cpp
+++ b/firmware/throttle/src/timers.cpp
@@ -4,13 +4,14 @@
  */
 
 
-#include "can_protocols/throttle_can_protocol.h"
-#include "oscc_timer.h"
+#include <Arduino.h>
 
-#include "timers.h"
-#include "globals.h"
+#include "can_protocols/throttle_can_protocol.h"
 #include "communications.h"
+#include "globals.h"
+#include "oscc_timer.h"
 #include "throttle_control.h"
+#include "timers.h"
 
 
 /*


### PR DESCRIPTION
This PR looks like a lot happened but it was mostly alphabetizing `#include` lines, fixing up spots where the style guideline wasn't being followed, and initializing all structs to zero to get rid of all Valgrind warnings.