### PR TITLE
brake pressure update

### DIFF
--- a/api/include/vehicles/kia_soul_ev.h
+++ b/api/include/vehicles/kia_soul_ev.h
@@ -122,53 +122,53 @@ typedef struct
  * @brief Minimum allowed voltage for the low spoof signal voltage. [volts]
  *
  */
-#define BRAKE_SPOOF_LOW_SIGNAL_VOLTAGE_MIN ( 0.303 )
+#define BRAKE_SPOOF_LOW_SIGNAL_VOLTAGE_MIN ( 0.333 )
 
 /*
  * @brief Maximum allowed voltage for the low spoof signal voltage. [volts]
  *
  */
-#define BRAKE_SPOOF_LOW_SIGNAL_VOLTAGE_MAX ( 1.40 )
+#define BRAKE_SPOOF_LOW_SIGNAL_VOLTAGE_MAX ( 1.12 )
 
 /**
  * @brief Minimum allowed voltage for the high spoof signal voltage. [volts]
  *
  */
-#define BRAKE_SPOOF_HIGH_SIGNAL_VOLTAGE_MIN ( 0.635 )
+#define BRAKE_SPOOF_HIGH_SIGNAL_VOLTAGE_MIN ( 0.698 )
 
 /**
  * @brief Maximum allowed voltage for the high spoof signal voltage. [volts]
  *
  */
-#define BRAKE_SPOOF_HIGH_SIGNAL_VOLTAGE_MAX ( 2.87 )
+#define BRAKE_SPOOF_HIGH_SIGNAL_VOLTAGE_MAX ( 2.29 )
 
 /*
  * @brief Minimum allowed value for the low spoof signal value. [steps]
  *
  * Equal to \ref BRAKE_SPOOF_LOW_SIGNAL_VOLTAGE_MIN * \ref STEPS_PER_VOLT.
  */
-#define BRAKE_SPOOF_LOW_SIGNAL_RANGE_MIN ( 249 )
+#define BRAKE_SPOOF_LOW_SIGNAL_RANGE_MIN ( 273 )
 
 /*
  * @brief Minimum allowed value for the low spoof signal value. [steps]
  *
  * Equal to \ref BRAKE_SPOOF_LOW_SIGNAL_VOLTAGE_MAX * \ref STEPS_PER_VOLT.
  */
-#define BRAKE_SPOOF_LOW_SIGNAL_RANGE_MAX ( 1146 )
+#define BRAKE_SPOOF_LOW_SIGNAL_RANGE_MAX ( 917 )
 
 /*
  * @brief Minimum allowed value for the low spoof signal value. [steps]
  *
  * Equal to \ref BRAKE_SPOOF_HIGH_SIGNAL_VOLTAGE_MIN * \ref STEPS_PER_VOLT.
  */
-#define BRAKE_SPOOF_HIGH_SIGNAL_RANGE_MIN ( 521 )
+#define BRAKE_SPOOF_HIGH_SIGNAL_RANGE_MIN ( 572 )
 
 /*
  * @brief Minimum allowed value for the low spoof signal value. [steps]
  *
  * Equal to \ref BRAKE_SPOOF_HIGH_SIGNAL_VOLTAGE_MAX * \ref STEPS_PER_VOLT.
  */
-#define BRAKE_SPOOF_HIGH_SIGNAL_RANGE_MAX ( 2351 )
+#define BRAKE_SPOOF_HIGH_SIGNAL_RANGE_MAX ( 1876 )
 
 /*
  * @brief Calculation to convert a brake position to a low spoof voltage.

--- a/firmware/brake/kia_soul_ev/tests/features/receiving_messages.feature
+++ b/firmware/brake/kia_soul_ev/tests/features/receiving_messages.feature
@@ -39,12 +39,12 @@ Feature: Receiving commands
 
     Examples:
       | high   | low    |
-      |  2300  |  250  |
-      |  2000  |  300  |
+      |  1876  |  273  |
+      |  1800  |  300  |
       |  1500  |  500  |
       |  1000  |  750  |
-      |  750   |  1000  |
-      |  550   |  1100  |
+      |  750   |  900  |
+      |  572   |  917  |
 
 
   Scenario Outline: Spoof value sent from application outside valid range
@@ -57,7 +57,7 @@ Feature: Receiving commands
 
     Examples:
       | high  | low   | high_clamped | low_clamped |
-      |  4000 |  0    | 2351         |  249        |
-      |  3500 |  500  | 2351         |  500        |
-      |  500  |  3500 | 521          |  1146       |
-      |  0    |  4000 | 521          |  1146       |
+      |  4000 |  0    | 1876         |  273        |
+      |  3500 |  500  | 1876         |  500        |
+      |  500  |  3500 | 572          |  917        |
+      |  0    |  4000 | 572          |  917        |


### PR DESCRIPTION
Prior to this PR, the brake pressure applied to the Soul EV was to high (80 bar range instead of 70 bar range). This PR corrects the min and max brake ranges and voltages. The brake fault does not appear anymore with these modifications. Field tested.