### PR TITLE
Fix rustup CI issues

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,8 +22,10 @@ node('arduino') {
         sh 'cd firmware && mkdir build_kia_soul_petrol_unit_tests && cd build_kia_soul_petrol_unit_tests && cmake .. -DKIA_SOUL=ON -DTESTS=ON -DCMAKE_BUILD_TYPE=Release && make run-unit-tests'
         echo 'Kia Soul Petrol Unit Tests Complete!'
       }, 'kia soul petrol property-based tests': {
-        sh 'cd firmware && mkdir build_kia_soul_petrol_property_tests && cd build_kia_soul_petrol_property_tests && cmake .. -DKIA_SOUL=ON -DTESTS=ON -DCMAKE_BUILD_TYPE=Release && make run-property-tests'
-        echo 'Kia Soul Petrol Property-Based Tests Complete!'
+        withEnv(["PATH+CARGO=$HOME/.cargo/bin"]) {
+          sh 'cd firmware && mkdir build_kia_soul_petrol_property_tests && cd build_kia_soul_petrol_property_tests && cmake .. -DKIA_SOUL=ON -DTESTS=ON -DCMAKE_BUILD_TYPE=Release && make run-property-tests'
+          echo 'Kia Soul Petrol Property-Based Tests Complete!'
+        }
       }
       echo 'Kia Soul Petrol Tests Complete!'
     }
@@ -32,8 +34,10 @@ node('arduino') {
         sh 'cd firmware && mkdir build_kia_soul_ev_unit_tests && cd build_kia_soul_ev_unit_tests && cmake .. -DKIA_SOUL_EV=ON -DTESTS=ON -DCMAKE_BUILD_TYPE=Release && make run-unit-tests'
         echo 'Kia Soul EV Unit Tests Complete!'
       }, 'kia soul ev property-based tests': {
-        sh 'cd firmware && mkdir build_kia_soul_ev_property_tests && cd build_kia_soul_ev_property_tests && cmake .. -DKIA_SOUL_EV=ON -DTESTS=ON -DCMAKE_BUILD_TYPE=Release && make run-property-tests'
-        echo 'Kia Soul EV Property-Based Tests Complete!'
+        withEnv(["PATH+CARGO=$HOME/.cargo/bin"]) {
+          sh 'cd firmware && mkdir build_kia_soul_ev_property_tests && cd build_kia_soul_ev_property_tests && cmake .. -DKIA_SOUL_EV=ON -DTESTS=ON -DCMAKE_BUILD_TYPE=Release && make run-property-tests'
+          echo 'Kia Soul EV Property-Based Tests Complete!'
+        }
       }
       echo 'Kia Soul EV Tests Complete!'
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ node('arduino') {
         echo 'Kia Soul Petrol Unit Tests Complete!'
       }, 'kia soul petrol property-based tests': {
         withEnv(["PATH+CARGO=$HOME/.cargo/bin"]) {
-          sh 'which rustup && cd firmware && mkdir build_kia_soul_petrol_property_tests && cd build_kia_soul_petrol_property_tests && cmake .. -DKIA_SOUL=ON -DTESTS=ON -DCMAKE_BUILD_TYPE=Release && make run-property-tests'
+          sh 'cd firmware && mkdir build_kia_soul_petrol_property_tests && cd build_kia_soul_petrol_property_tests && cmake .. -DKIA_SOUL=ON -DTESTS=ON -DCMAKE_BUILD_TYPE=Release && make run-property-tests'
           echo 'Kia Soul Petrol Property-Based Tests Complete!'
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,6 @@ node('arduino') {
         sh 'cd firmware && mkdir build_kia_soul_petrol_unit_tests && cd build_kia_soul_petrol_unit_tests && cmake .. -DKIA_SOUL=ON -DTESTS=ON -DCMAKE_BUILD_TYPE=Release && make run-unit-tests'
         echo 'Kia Soul Petrol Unit Tests Complete!'
       }, 'kia soul petrol property-based tests': {
-        sh 'which rustup'
         withEnv(["PATH+CARGO=$HOME/.cargo/bin"]) {
           sh 'which rustup && cd firmware && mkdir build_kia_soul_petrol_property_tests && cd build_kia_soul_petrol_property_tests && cmake .. -DKIA_SOUL=ON -DTESTS=ON -DCMAKE_BUILD_TYPE=Release && make run-property-tests'
           echo 'Kia Soul Petrol Property-Based Tests Complete!'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ node('arduino') {
         echo 'Kia Soul Petrol Unit Tests Complete!'
       }, 'kia soul petrol property-based tests': {
         withEnv(["PATH+CARGO=$HOME/.cargo/bin"]) {
-          sh 'cd firmware && mkdir build_kia_soul_petrol_property_tests && cd build_kia_soul_petrol_property_tests && cmake .. -DKIA_SOUL=ON -DTESTS=ON -DCMAKE_BUILD_TYPE=Release && make run-property-tests'
+          sh 'rustup self update && rustup update && rustup install 1.20.0 && rustup component add rust-src && cd firmware && mkdir build_kia_soul_petrol_property_tests && cd build_kia_soul_petrol_property_tests && cmake .. -DKIA_SOUL=ON -DTESTS=ON -DCMAKE_BUILD_TYPE=Release && make run-property-tests'
           echo 'Kia Soul Petrol Property-Based Tests Complete!'
         }
       }
@@ -35,7 +35,7 @@ node('arduino') {
         echo 'Kia Soul EV Unit Tests Complete!'
       }, 'kia soul ev property-based tests': {
         withEnv(["PATH+CARGO=$HOME/.cargo/bin"]) {
-          sh 'cd firmware && mkdir build_kia_soul_ev_property_tests && cd build_kia_soul_ev_property_tests && cmake .. -DKIA_SOUL_EV=ON -DTESTS=ON -DCMAKE_BUILD_TYPE=Release && make run-property-tests'
+          sh 'rustup self update && rustup update && rustup install 1.20.0 && rustup component add rust-src && cd firmware && mkdir build_kia_soul_ev_property_tests && cd build_kia_soul_ev_property_tests && cmake .. -DKIA_SOUL_EV=ON -DTESTS=ON -DCMAKE_BUILD_TYPE=Release && make run-property-tests'
           echo 'Kia Soul EV Property-Based Tests Complete!'
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,8 +22,9 @@ node('arduino') {
         sh 'cd firmware && mkdir build_kia_soul_petrol_unit_tests && cd build_kia_soul_petrol_unit_tests && cmake .. -DKIA_SOUL=ON -DTESTS=ON -DCMAKE_BUILD_TYPE=Release && make run-unit-tests'
         echo 'Kia Soul Petrol Unit Tests Complete!'
       }, 'kia soul petrol property-based tests': {
+        sh 'which rustup'
         withEnv(["PATH+CARGO=$HOME/.cargo/bin"]) {
-          sh 'cd firmware && mkdir build_kia_soul_petrol_property_tests && cd build_kia_soul_petrol_property_tests && cmake .. -DKIA_SOUL=ON -DTESTS=ON -DCMAKE_BUILD_TYPE=Release && make run-property-tests'
+          sh 'which rustup && cd firmware && mkdir build_kia_soul_petrol_property_tests && cd build_kia_soul_petrol_property_tests && cmake .. -DKIA_SOUL=ON -DTESTS=ON -DCMAKE_BUILD_TYPE=Release && make run-property-tests'
           echo 'Kia Soul Petrol Property-Based Tests Complete!'
         }
       }

--- a/firmware/brake/kia_soul_ev/tests/CMakeLists.txt
+++ b/firmware/brake/kia_soul_ev/tests/CMakeLists.txt
@@ -56,5 +56,5 @@ add_custom_target(
 add_custom_target(
     run-brake-property-tests
     COMMAND
-    cargo test -- --test-threads=1
+    cargo +1.20.0 test -- --test-threads=1
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/property)

--- a/firmware/brake/kia_soul_petrol/tests/CMakeLists.txt
+++ b/firmware/brake/kia_soul_petrol/tests/CMakeLists.txt
@@ -59,5 +59,5 @@ add_custom_target(
 add_custom_target(
     run-brake-property-tests
     COMMAND
-    cargo test -- --test-threads=1
+    cargo +1.20.0 test -- --test-threads=1
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/property)

--- a/firmware/steering/tests/CMakeLists.txt
+++ b/firmware/steering/tests/CMakeLists.txt
@@ -59,5 +59,5 @@ add_custom_target(
 add_custom_target(
     run-steering-property-tests
     COMMAND
-    cargo test -- --test-threads=1
+    cargo +1.20.0 test -- --test-threads=1
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/property)

--- a/firmware/throttle/tests/CMakeLists.txt
+++ b/firmware/throttle/tests/CMakeLists.txt
@@ -56,5 +56,5 @@ add_custom_target(
 add_custom_target(
     run-throttle-property-tests
     COMMAND
-    cargo test -- --test-threads=1
+    cargo +1.20.0 test -- --test-threads=1
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/property)

--- a/firmware/throttle/tests/CMakeLists.txt
+++ b/firmware/throttle/tests/CMakeLists.txt
@@ -56,5 +56,5 @@ add_custom_target(
 add_custom_target(
     run-throttle-property-tests
     COMMAND
-    which rustup && cargo test -- --test-threads=1
+    cargo test -- --test-threads=1
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/property)

--- a/firmware/throttle/tests/CMakeLists.txt
+++ b/firmware/throttle/tests/CMakeLists.txt
@@ -56,5 +56,5 @@ add_custom_target(
 add_custom_target(
     run-throttle-property-tests
     COMMAND
-    cargo test -- --test-threads=1
+    which rustup && cargo test -- --test-threads=1
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/property)


### PR DESCRIPTION
Prior to this pull request, builds were failing due to inconsistent versioning of rustup on the build machines. This commit adds the correct environment variable to the path via Jenkinsfile, updates rustup and installs the targeted toolchain (1.20.0 to deal with the bindgen/clap crate versioning bug). It also uses that toolchain in the CMake files for each test suite to run the tests.