### PR TITLE
Incorporate a template for raising issues.

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -28,7 +28,8 @@ tackle it!
 <!-- How can we make it happen too? -->
 
 ### Version info
-_What's the output of running `git describe --tags` in your OSCC directory?_
+- _What's the output of running `git describe --tags` in your OSCC directory?_
+- _Is this the same version flashed onto the hardware?_
 
 ### Hardware info
 <!-- Are you using a custom board or something received from us? -->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,56 @@
+<!-- Thanks for filing an OSCC issue! You're making our world a better place!-->
+
+<!-- Questions about purchasing and pricing for OSCC boards or DriveKit?
+Shoot an email to drivekit@polysync.io -->
+
+
+
+<!--
+Interested in a new feature?
+-->
+
+### Proposed feature
+<!-- What would you like to accomplish? -->
+
+### Use case
+<!-- How would you like to do it? -->
+
+
+
+<!--
+Missing documentaion?
+-->
+
+### Expected Information
+<!-- What information would help you? -->
+
+### Available Documentation
+<!-- What were you able to find?-->
+
+
+
+<!--
+Technical issue?
+-->
+
+### Expected behavior
+<!-- What should be happening?? -->
+
+### Actual behavior
+<!-- What behavior are you seeing? -->
+
+### Steps to reproduce
+<!-- How can we make it happen too? -->
+
+### Version info
+_What's the output of running `git describe --tags` in your OSCC directory?_
+
+
+### Hardware info
+<!-- Are you using a custom board or something received from us? -->
+
+
+
+<!--
+Something else? Let us know!
+-->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -3,7 +3,7 @@ Thanks for filing an OSCC issue! You're making our ecosystem a better place!
 
 Below are some templates to get you started, filling out any that are relevant
 to this issue will help us a lot! Feel free to delete any information or text
-that isn't relevant to your issue liberally.
+that isn't relevant to your issue.
 -->
 
 <!-- Questions about purchasing and pricing for OSCC boards or DriveKit?

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,10 @@
-<!-- Thanks for filing an OSCC issue! You're making our world a better place!-->
+<!--
+Thanks for filing an OSCC issue! You're making our ecosystem a better place!
+
+Below are some templates to get you started, filling out any that are relevant
+to this issue will help us a lot! Feel free to delete any information or text
+that isn't relevant to your issue liberally.
+-->
 
 <!-- Questions about purchasing and pricing for OSCC boards or DriveKit?
 Shoot an email to drivekit@polysync.io -->
@@ -6,35 +12,14 @@ Shoot an email to drivekit@polysync.io -->
 
 
 <!--
-Interested in a new feature?
--->
+Technical issue template.
 
-### Proposed feature
-<!-- What would you like to accomplish? -->
-
-### Use case
-<!-- How would you like to do it? -->
-
-
-
-<!--
-Missing documentaion?
--->
-
-### Expected Information
-<!-- What information would help you? -->
-
-### Available Documentation
-<!-- What were you able to find?-->
-
-
-
-<!--
-Technical issue?
+Are you having a technical issue? Fill in the following blocks to help us
+tackle it!
 -->
 
 ### Expected behavior
-<!-- What should be happening?? -->
+<!-- What should be happening? -->
 
 ### Actual behavior
 <!-- What behavior are you seeing? -->
@@ -45,12 +30,41 @@ Technical issue?
 ### Version info
 _What's the output of running `git describe --tags` in your OSCC directory?_
 
-
 ### Hardware info
 <!-- Are you using a custom board or something received from us? -->
 
 
 
 <!--
-Something else? Let us know!
+Feature/changes issue template.
+
+Are you interested in a new feature or a change to something that exists?
+Fill in the following blocks to help us understand it!
+-->
+
+### Proposed feature or changes
+<!-- What would you like to accomplish? -->
+
+### Use case
+<!-- How would you like to do it? -->
+
+
+
+<!--
+Documentation issue template.
+
+Have you found a bug in documentation or wish something was documented that
+isn't? Fill in the following blocks to help us help you!
+-->
+
+### Documentation expected
+<!-- What information would help you? Where would you expect to find it? -->
+
+### Documentation available
+<!-- What were you able to find? Was it in the right spot? -->
+
+
+<!--
+Is your issue something that doesn't fit any of the templates above?
+Let us know here!
 -->


### PR DESCRIPTION
Prior to this commit, when raising a new issue users are presented with a blank canvas.

This leads to inconsitent reports from users as well the requirement for the maintainers to poll for information that we generally always need up front. As a solution, Github facilitates templating the default issue dialogue.

This PR represents an attempt at templating the issue dialogue so that users are prompted to provide information that would be helpful to the maintainers from the outset.

For an example of another project that employs a helpful issue template, see [rust-bindgen](https://github.com/rust-lang-nursery/rust-bindgen/issues). Click the green "New Issue" button to see a great template in action.