### PR TITLE
Remove toolchain updating from Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ node('arduino') {
         echo 'Kia Soul Petrol Unit Tests Complete!'
       }, 'kia soul petrol property-based tests': {
         withEnv(["PATH+CARGO=$HOME/.cargo/bin"]) {
-          sh 'rustup self update && rustup update && rustup install 1.20.0 && rustup component add rust-src && cd firmware && mkdir build_kia_soul_petrol_property_tests && cd build_kia_soul_petrol_property_tests && cmake .. -DKIA_SOUL=ON -DTESTS=ON -DCMAKE_BUILD_TYPE=Release && make run-property-tests'
+          sh 'cd firmware && mkdir build_kia_soul_petrol_property_tests && cd build_kia_soul_petrol_property_tests && cmake .. -DKIA_SOUL=ON -DTESTS=ON -DCMAKE_BUILD_TYPE=Release && make run-property-tests'
           echo 'Kia Soul Petrol Property-Based Tests Complete!'
         }
       }
@@ -35,7 +35,7 @@ node('arduino') {
         echo 'Kia Soul EV Unit Tests Complete!'
       }, 'kia soul ev property-based tests': {
         withEnv(["PATH+CARGO=$HOME/.cargo/bin"]) {
-          sh 'rustup self update && rustup update && rustup install 1.20.0 && rustup component add rust-src && cd firmware && mkdir build_kia_soul_ev_property_tests && cd build_kia_soul_ev_property_tests && cmake .. -DKIA_SOUL_EV=ON -DTESTS=ON -DCMAKE_BUILD_TYPE=Release && make run-property-tests'
+          sh 'cd firmware && mkdir build_kia_soul_ev_property_tests && cd build_kia_soul_ev_property_tests && cmake .. -DKIA_SOUL_EV=ON -DTESTS=ON -DCMAKE_BUILD_TYPE=Release && make run-property-tests'
           echo 'Kia Soul EV Property-Based Tests Complete!'
         }
       }


### PR DESCRIPTION
Tiny PR to remove rust toolchain update responsibility from the Jenkinsfile now that the build machines are in a consistent state.