### PR TITLE
Remove api version dependency

### DIFF
--- a/api/include/can_protocols/brake_can_protocol.h
+++ b/api/include/can_protocols/brake_can_protocol.h
@@ -120,7 +120,7 @@ typedef struct
                        *   Byte 0 should be \ref OSCC_MAGIC_BYTE_0.
                        *   Byte 1 should be \ref OSCC_MAGIC_BYTE_1. */
 
-    float pedal_command; /* Brake Request 0 to 1 where 1 is 100% */
+    float pedal_command; /* Brake Request 0.0 to 1.0 where 1.0 is 100% */
 
     uint8_t reserved[2]; /*!< Reserved. */
 

--- a/api/include/can_protocols/brake_can_protocol.h
+++ b/api/include/can_protocols/brake_can_protocol.h
@@ -120,17 +120,10 @@ typedef struct
                        *   Byte 0 should be \ref OSCC_MAGIC_BYTE_0.
                        *   Byte 1 should be \ref OSCC_MAGIC_BYTE_1. */
 
-#if defined(KIA_SOUL)
-    uint16_t pedal_command; /*!< Pedal command. [65535 == 100%] */
-
-    uint8_t reserved[4]; /*!< Reserved. */
-#elif defined(KIA_SOUL_EV)
-    uint16_t spoof_value_low; /*!< Value to be sent on the low spoof signal. */
-
-    uint16_t spoof_value_high; /*!< Value to be sent on the high spoof signal. */
+    float pedal_command; /* Brake Request 0 to 1 where 1 is 100% */
 
     uint8_t reserved[2]; /*!< Reserved. */
-#endif
+
 } oscc_brake_command_s;
 
 

--- a/api/include/can_protocols/steering_can_protocol.h
+++ b/api/include/can_protocols/steering_can_protocol.h
@@ -120,13 +120,13 @@ typedef struct
                        *   Byte 0 should be \ref OSCC_MAGIC_BYTE_0.
                        *   Byte 1 should be \ref OSCC_MAGIC_BYTE_1. */
 
-    float torque_command; /* Steering torque request [-1, 1] where -1 is max
-                           * torque in the counterclockwise direction and 1 is
-                           * max torque in the clockwise direction.
+    float torque_command; /* Steering torque request [-1.0, 1.0] where -1.0 is
+                           * max torque in the counterclockwise direction and 1
+                           * is max torque in the clockwise direction.
                            * (Note: this is inverse to standard torque direction)
                            */
 
-    uint8_t reserved[2]; /*!< Reserved. */
+    uint8_t reserved[2]; /*!< Reserved. */  
 } oscc_steering_command_s;
 
 

--- a/api/include/can_protocols/steering_can_protocol.h
+++ b/api/include/can_protocols/steering_can_protocol.h
@@ -120,9 +120,11 @@ typedef struct
                        *   Byte 0 should be \ref OSCC_MAGIC_BYTE_0.
                        *   Byte 1 should be \ref OSCC_MAGIC_BYTE_1. */
 
-    uint16_t spoof_value_low; /*!< Value to be sent on the low spoof signal. */
-
-    uint16_t spoof_value_high; /*!< Value to be sent on the high spoof signal. */
+    float torque_command; /* Steering torque request [-1, 1] where -1 is max
+                           * torque in the counterclockwise direction and 1 is
+                           * max torque in the clockwise direction.
+                           * (Note: this is inverse to standard torque direction)
+                           */
 
     uint8_t reserved[2]; /*!< Reserved. */
 } oscc_steering_command_s;

--- a/api/include/can_protocols/throttle_can_protocol.h
+++ b/api/include/can_protocols/throttle_can_protocol.h
@@ -120,7 +120,7 @@ typedef struct
                        *   Byte 0 should be \ref OSCC_MAGIC_BYTE_0.
                        *   Byte 1 should be \ref OSCC_MAGIC_BYTE_1. */
 
-    float torque_request; /* Torque request from 0 to 1 where 1 is 100% */
+    float torque_request; /* Torque request from 0.0 to 1.0 where 1.0 is 100% */
 
     uint8_t reserved[2]; /*!< Reserved. */
 } oscc_throttle_command_s;

--- a/api/include/can_protocols/throttle_can_protocol.h
+++ b/api/include/can_protocols/throttle_can_protocol.h
@@ -120,9 +120,7 @@ typedef struct
                        *   Byte 0 should be \ref OSCC_MAGIC_BYTE_0.
                        *   Byte 1 should be \ref OSCC_MAGIC_BYTE_1. */
 
-    uint16_t spoof_value_low; /*!< Value to be sent on the low spoof signal. */
-
-    uint16_t spoof_value_high; /*!< Value to be sent on the high spoof signal. */
+    float torque_request; /* Torque request from 0 to 1 where 1 is 100% */
 
     uint8_t reserved[2]; /*!< Reserved. */
 } oscc_throttle_command_s;

--- a/api/include/vehicles.h
+++ b/api/include/vehicles.h
@@ -15,5 +15,7 @@
 #include "vehicles/kia_soul_ev.h"
 #endif
 
+#define CONSTRAIN(amt, low, high) ((amt) < (low) ? (low) : ((amt) > (high) ? (high) : (amt)))
+
 
 #endif /* _OSCC_VEHICLES_H_ */

--- a/api/include/vehicles/kia_soul_petrol.h
+++ b/api/include/vehicles/kia_soul_petrol.h
@@ -114,7 +114,7 @@ typedef struct
  * @brief Maximum allowable brake value.
  *
  */
-#define MAXIMUM_BRAKE_COMMAND ( 52428 )
+#define MAXIMUM_BRAKE_COMMAND ( 1 )
 
 /*
  * @brief Calculation to convert a brake position to a pedal position.

--- a/api/include/vehicles/kia_soul_petrol.h
+++ b/api/include/vehicles/kia_soul_petrol.h
@@ -108,13 +108,13 @@ typedef struct
  * @brief Minimum allowable brake value.
  *
  */
-#define MINIMUM_BRAKE_COMMAND ( 0 )
+#define MINIMUM_BRAKE_COMMAND ( 0.0 )
 
 /*
  * @brief Maximum allowable brake value.
  *
  */
-#define MAXIMUM_BRAKE_COMMAND ( 1 )
+#define MAXIMUM_BRAKE_COMMAND ( 1.0 )
 
 /*
  * @brief Calculation to convert a brake position to a pedal position.

--- a/api/src/oscc.c
+++ b/api/src/oscc.c
@@ -107,43 +107,7 @@ oscc_result_t oscc_publish_brake_position( double brake_position )
         .magic[1] = ( uint8_t ) OSCC_MAGIC_BYTE_1
     };
 
-#if defined(KIA_SOUL)
-    const double clamped_position = ( double ) CONSTRAIN (
-            brake_position * MAXIMUM_BRAKE_COMMAND,
-            MINIMUM_BRAKE_COMMAND,
-            MAXIMUM_BRAKE_COMMAND );
-
-    brake_cmd.pedal_command = ( uint16_t ) BRAKE_POSITION_TO_PEDAL( clamped_position );
-
-#elif defined(KIA_SOUL_EV)
-    const double clamped_position = CONSTRAIN(
-        brake_position,
-        MINIMUM_BRAKE_COMMAND,
-        MAXIMUM_BRAKE_COMMAND);
-
-
-    double spoof_voltage_low = BRAKE_POSITION_TO_VOLTS_LOW( clamped_position );
-
-    spoof_voltage_low = CONSTRAIN(
-        spoof_voltage_low,
-        BRAKE_SPOOF_LOW_SIGNAL_VOLTAGE_MIN,
-        BRAKE_SPOOF_LOW_SIGNAL_VOLTAGE_MAX);
-
-
-    double spoof_voltage_high = BRAKE_POSITION_TO_VOLTS_HIGH( clamped_position );
-
-    spoof_voltage_high = CONSTRAIN(
-        spoof_voltage_high,
-        BRAKE_SPOOF_HIGH_SIGNAL_VOLTAGE_MIN,
-        BRAKE_SPOOF_HIGH_SIGNAL_VOLTAGE_MAX);
-
-
-    const uint16_t spoof_value_low = STEPS_PER_VOLT * spoof_voltage_low;
-    const uint16_t spoof_value_high = STEPS_PER_VOLT * spoof_voltage_high;
-
-    brake_cmd.spoof_value_low = spoof_value_low;
-    brake_cmd.spoof_value_high = spoof_value_high;
-#endif
+    brake_cmd.pedal_command = (float) brake_position;
 
     result = oscc_can_write(
         OSCC_BRAKE_COMMAND_CAN_ID,
@@ -165,34 +129,7 @@ oscc_result_t oscc_publish_throttle_position( double throttle_position )
         .magic[1] = ( uint8_t ) OSCC_MAGIC_BYTE_1
     };
 
-
-    const double clamped_position = CONSTRAIN(
-        throttle_position,
-        MINIMUM_THROTTLE_COMMAND,
-        MAXIMUM_THROTTLE_COMMAND);
-
-
-    double spoof_voltage_low = THROTTLE_POSITION_TO_VOLTS_LOW( clamped_position );
-
-    spoof_voltage_low = CONSTRAIN(
-        spoof_voltage_low,
-        THROTTLE_SPOOF_LOW_SIGNAL_VOLTAGE_MIN,
-        THROTTLE_SPOOF_LOW_SIGNAL_VOLTAGE_MAX);
-
-
-    double spoof_voltage_high = THROTTLE_POSITION_TO_VOLTS_HIGH( clamped_position );
-
-    spoof_voltage_high = CONSTRAIN(
-        spoof_voltage_high,
-        THROTTLE_SPOOF_HIGH_SIGNAL_VOLTAGE_MIN,
-        THROTTLE_SPOOF_HIGH_SIGNAL_VOLTAGE_MAX);
-
-
-    const uint16_t spoof_value_low = STEPS_PER_VOLT * spoof_voltage_low;
-    const uint16_t spoof_value_high = STEPS_PER_VOLT * spoof_voltage_high;
-
-    throttle_cmd.spoof_value_low = spoof_value_low;
-    throttle_cmd.spoof_value_high = spoof_value_high;
+    throttle_cmd.torque_request = (float) throttle_position;
 
     result = oscc_can_write(
         OSCC_THROTTLE_COMMAND_CAN_ID,
@@ -214,34 +151,7 @@ oscc_result_t oscc_publish_steering_torque( double torque )
         .magic[1] = ( uint8_t ) OSCC_MAGIC_BYTE_1
     };
 
-
-    const double clamped_torque = CONSTRAIN(
-        torque * MAXIMUM_TORQUE_COMMAND,
-        MINIMUM_TORQUE_COMMAND,
-        MAXIMUM_TORQUE_COMMAND);
-
-
-    double spoof_voltage_low = STEERING_TORQUE_TO_VOLTS_LOW( clamped_torque );
-
-    spoof_voltage_low = CONSTRAIN(
-        spoof_voltage_low,
-        STEERING_SPOOF_LOW_SIGNAL_VOLTAGE_MIN,
-        STEERING_SPOOF_LOW_SIGNAL_VOLTAGE_MAX);
-
-
-    double spoof_voltage_high = STEERING_TORQUE_TO_VOLTS_HIGH( clamped_torque );
-
-    spoof_voltage_high = CONSTRAIN(
-        spoof_voltage_high,
-        STEERING_SPOOF_HIGH_SIGNAL_VOLTAGE_MIN,
-        STEERING_SPOOF_HIGH_SIGNAL_VOLTAGE_MAX);
-
-
-    const uint16_t spoof_value_low = STEPS_PER_VOLT * spoof_voltage_low;
-    const uint16_t spoof_value_high = STEPS_PER_VOLT * spoof_voltage_high;
-
-    steering_cmd.spoof_value_low = spoof_value_low;
-    steering_cmd.spoof_value_high = spoof_value_high;
+    steering_cmd.torque_command = (float) torque;
 
     result = oscc_can_write(
         OSCC_STEERING_COMMAND_CAN_ID,

--- a/firmware/brake/kia_soul_ev/src/communications.cpp
+++ b/firmware/brake/kia_soul_ev/src/communications.cpp
@@ -14,6 +14,7 @@
 #include "globals.h"
 #include "mcp_can.h"
 #include "oscc_can.h"
+#include "vehicles.h"
 
 
 static void process_rx_frame(
@@ -130,9 +131,29 @@ static void process_brake_command(
         const oscc_brake_command_s * const brake_command =
                 (oscc_brake_command_s *) data;
 
-        update_brake(
-            brake_command->spoof_value_high,
-            brake_command->spoof_value_low );
+        const float clamped_position = CONSTRAIN(
+            brake_command->pedal_command,
+            MINIMUM_BRAKE_COMMAND,
+            MAXIMUM_BRAKE_COMMAND);
+
+        float spoof_voltage_low = BRAKE_POSITION_TO_VOLTS_LOW( clamped_position );
+
+        spoof_voltage_low = CONSTRAIN(
+            spoof_voltage_low,
+            BRAKE_SPOOF_LOW_SIGNAL_VOLTAGE_MIN,
+            BRAKE_SPOOF_LOW_SIGNAL_VOLTAGE_MAX);
+
+        float spoof_voltage_high = BRAKE_POSITION_TO_VOLTS_HIGH( clamped_position );
+
+        spoof_voltage_high = CONSTRAIN(
+            spoof_voltage_high,
+            BRAKE_SPOOF_HIGH_SIGNAL_VOLTAGE_MIN,
+            BRAKE_SPOOF_HIGH_SIGNAL_VOLTAGE_MAX);
+
+        const uint16_t spoof_value_low = STEPS_PER_VOLT * spoof_voltage_low;
+        const uint16_t spoof_value_high = STEPS_PER_VOLT * spoof_voltage_high;
+
+        update_brake( spoof_value_high, spoof_value_low );
 
         g_brake_command_timeout = false;
     }

--- a/firmware/brake/kia_soul_ev/src/communications.cpp
+++ b/firmware/brake/kia_soul_ev/src/communications.cpp
@@ -138,8 +138,6 @@ static void process_brake_command(
         const uint16_t spoof_value_high = STEPS_PER_VOLT * spoof_voltage_high;
 
         update_brake( spoof_value_high, spoof_value_low );
-
-        g_brake_command_timeout = false;
     }
 }
 

--- a/firmware/brake/kia_soul_ev/tests/features/receiving_messages.feature
+++ b/firmware/brake/kia_soul_ev/tests/features/receiving_messages.feature
@@ -32,32 +32,32 @@ Feature: Receiving commands
   Scenario Outline: Spoof value sent from application
     Given brake control is enabled
 
-    When a command is received with spoof values <high> and <low>
+    When a command is received with request value <value>
 
     Then <high> should be sent to DAC A
     And <low> should be sent to DAC B
 
     Examples:
-      | high   | low    |
-      |  1876  |  273  |
-      |  1800  |  300  |
-      |  1500  |  500  |
-      |  1000  |  750  |
-      |  750   |  900  |
-      |  572   |  917  |
+      | value | high   | low  |
+      | 1     | 1875   | 917  |
+      | 0.942 | 1800   | 880  |
+      | 0.712 | 1500   | 731  |
+      | 0.329 | 1000   | 484  |
+      | 0.137 | 750    | 361  |
+      | 0     | 572    | 273  |
 
 
   Scenario Outline: Spoof value sent from application outside valid range
     Given brake control is enabled
 
-    When a command is received with spoof values <high> and <low>
+    When a command is received with request value <value>
 
     Then <high_clamped> should be sent to DAC A
     And <low_clamped> should be sent to DAC B
 
     Examples:
-      | high  | low   | high_clamped | low_clamped |
-      |  4000 |  0    | 1876         |  273        |
-      |  3500 |  500  | 1876         |  500        |
-      |  500  |  3500 | 572          |  917        |
-      |  0    |  4000 | 572          |  917        |
+      | value | high_clamped | low_clamped |
+      | 5     | 1875         |  917        |
+      | 2     | 1875         |  917        |
+      | -1    | 572          |  273        |
+      | -2    | 572          |  273        |

--- a/firmware/brake/kia_soul_ev/tests/features/step_definitions/receiving_messages.cpp
+++ b/firmware/brake/kia_soul_ev/tests/features/step_definitions/receiving_messages.cpp
@@ -43,10 +43,9 @@ WHEN("^a fault report is received$")
 }
 
 
-WHEN("^a command is received with spoof values (.*) and (.*)$")
+WHEN("^a command is received with request value (.*)$")
 {
-    REGEX_PARAM(uint16_t, high);
-    REGEX_PARAM(uint16_t, low);
+    REGEX_PARAM(float, value);
 
     g_mock_mcp_can_check_receive_return = CAN_MSGAVAIL;
     g_mock_mcp_can_read_msg_buf_id = OSCC_BRAKE_COMMAND_CAN_ID;
@@ -56,12 +55,7 @@ WHEN("^a command is received with spoof values (.*) and (.*)$")
 
     brake_command->magic[0] = OSCC_MAGIC_BYTE_0;
     brake_command->magic[1] = OSCC_MAGIC_BYTE_1;
-    brake_command->spoof_value_high = high;
-    brake_command->spoof_value_low = low;
+    brake_command->pedal_command = value;
 
     check_for_incoming_message();
-
-    update_brake(
-        brake_command->spoof_value_high,
-        brake_command->spoof_value_low);
 }

--- a/firmware/brake/kia_soul_ev/tests/property/Cargo.toml
+++ b/firmware/brake/kia_soul_ev/tests/property/Cargo.toml
@@ -10,7 +10,7 @@ quickcheck = "0.4.1"
 rand = "0.3.15"
 
 [build-dependencies]
-bindgen = "0.25.0"
+bindgen = "0.32.1"
 gcc = "0.3.51"
 
 [lib]

--- a/firmware/brake/kia_soul_ev/tests/property/build.rs
+++ b/firmware/brake/kia_soul_ev/tests/property/build.rs
@@ -58,6 +58,8 @@ fn main() {
         .whitelisted_var("BRAKE_SPOOF_LOW_SIGNAL_RANGE_MAX")
         .whitelisted_var("BRAKE_SPOOF_HIGH_SIGNAL_RANGE_MIN")
         .whitelisted_var("BRAKE_SPOOF_HIGH_SIGNAL_RANGE_MAX")
+        .whitelisted_var("MINIMUM_BRAKE_COMMAND")
+        .whitelisted_var("MAXIMUM_BRAKE_COMMAND")
         .whitelisted_type("oscc_brake_enable_s")
         .whitelisted_type("oscc_brake_disable_s")
         .whitelisted_type("oscc_brake_report_s")

--- a/firmware/brake/kia_soul_ev/tests/property/src/tests.rs
+++ b/firmware/brake/kia_soul_ev/tests/property/src/tests.rs
@@ -60,8 +60,7 @@ impl Arbitrary for oscc_brake_command_s {
     fn arbitrary<G: Gen>(g: &mut G) -> oscc_brake_command_s {
         oscc_brake_command_s {
             magic: [OSCC_MAGIC_BYTE_0 as u8, OSCC_MAGIC_BYTE_1 as u8],
-            spoof_value_low: u16::arbitrary(g),
-            spoof_value_high: u16::arbitrary(g),
+            pedal_command: f32::arbitrary(g),
             reserved: [u8::arbitrary(g); 2]
         }
     }
@@ -168,12 +167,8 @@ fn check_process_disable_command() {
 /// the brake firmware should send requested spoof values
 /// upon receiving a brake command message
 fn prop_output_accurate_spoofs(mut brake_command_msg: oscc_brake_command_s) -> TestResult {
-    brake_command_msg.spoof_value_low =
-        rand::thread_rng().gen_range(BRAKE_SPOOF_LOW_SIGNAL_RANGE_MIN as u16,
-                                     BRAKE_SPOOF_LOW_SIGNAL_RANGE_MAX as u16);
-    brake_command_msg.spoof_value_high =
-        rand::thread_rng().gen_range(BRAKE_SPOOF_HIGH_SIGNAL_RANGE_MIN as u16,
-                                     BRAKE_SPOOF_HIGH_SIGNAL_RANGE_MAX as u16);
+    brake_command_msg.pedal_command = rand::thread_rng().gen_range(0f32, 1f32);
+
     unsafe {
         g_brake_control_state.enabled = true;
 
@@ -183,8 +178,10 @@ fn prop_output_accurate_spoofs(mut brake_command_msg: oscc_brake_command_s) -> T
 
         check_for_incoming_message();
 
-        TestResult::from_bool(g_mock_dac_output_b == brake_command_msg.spoof_value_low &&
-                              g_mock_dac_output_a == brake_command_msg.spoof_value_high)
+        TestResult::from_bool(g_mock_dac_output_b >= BRAKE_SPOOF_LOW_SIGNAL_RANGE_MIN as u16 &&
+                              g_mock_dac_output_b <= BRAKE_SPOOF_LOW_SIGNAL_RANGE_MAX as u16 &&
+                              g_mock_dac_output_a >= BRAKE_SPOOF_HIGH_SIGNAL_RANGE_MIN as u16 &&
+                              g_mock_dac_output_a <= BRAKE_SPOOF_HIGH_SIGNAL_RANGE_MAX as u16)
     }
 }
 
@@ -200,10 +197,8 @@ fn check_output_accurate_spoofs() {
 /// upon receiving a brake command message
 fn prop_output_constrained_spoofs(brake_command_msg: oscc_brake_command_s) -> TestResult {
     unsafe {
-        if (brake_command_msg.spoof_value_low >= BRAKE_SPOOF_LOW_SIGNAL_RANGE_MIN as u16 &&
-            brake_command_msg.spoof_value_low <= BRAKE_SPOOF_LOW_SIGNAL_RANGE_MAX as u16) ||
-           (brake_command_msg.spoof_value_high >= BRAKE_SPOOF_HIGH_SIGNAL_RANGE_MIN as u16 &&
-            brake_command_msg.spoof_value_high <= BRAKE_SPOOF_HIGH_SIGNAL_RANGE_MAX as u16) {
+        if brake_command_msg.pedal_command >= MINIMUM_BRAKE_COMMAND as f32 &&
+            brake_command_msg.pedal_command <= MAXIMUM_BRAKE_COMMAND as f32 {
             return TestResult::discard();
         }
 

--- a/firmware/brake/kia_soul_petrol/src/brake_control.cpp
+++ b/firmware/brake/kia_soul_petrol/src/brake_control.cpp
@@ -241,7 +241,7 @@ void update_brake( void )
         time_between_loops /= 1000.0;
 
         static interpolate_range_s pressure_ranges =
-            { 0, 1, BRAKE_PRESSURE_MIN_IN_DECIBARS, BRAKE_PRESSURE_MAX_IN_DECIBARS };
+            { 0.0, 1.0, BRAKE_PRESSURE_MIN_IN_DECIBARS, BRAKE_PRESSURE_MAX_IN_DECIBARS };
 
         pressure_at_wheels_target = interpolate(
             g_brake_control_state.commanded_pedal_position,

--- a/firmware/brake/kia_soul_petrol/src/brake_control.cpp
+++ b/firmware/brake/kia_soul_petrol/src/brake_control.cpp
@@ -243,7 +243,7 @@ void update_brake( void )
         time_between_loops /= 1000.0;
 
         static interpolate_range_s pressure_ranges =
-            { 0, UINT16_MAX, BRAKE_PRESSURE_MIN_IN_DECIBARS, BRAKE_PRESSURE_MAX_IN_DECIBARS };
+            { 0, 1, BRAKE_PRESSURE_MIN_IN_DECIBARS, BRAKE_PRESSURE_MAX_IN_DECIBARS };
 
         pressure_at_wheels_target = interpolate(
             g_brake_control_state.commanded_pedal_position,
@@ -513,4 +513,3 @@ static void pump_startup_check( void )
 
     accumulator_turn_pump_off();
 }
-

--- a/firmware/brake/kia_soul_petrol/tests/features/receiving_messages.feature
+++ b/firmware/brake/kia_soul_petrol/tests/features/receiving_messages.feature
@@ -41,11 +41,11 @@ Feature: Receiving commands
 
     Examples:
       | left_pressure | right_pressure | command | solenoid     | duty_cycle |
-      |  120          |  120           |  20000  |  ACCUMULATOR |  105       |
-      |  160          |  160           |  20000  |  ACCUMULATOR |  104       |
-      |  190          |  190           |  20000  |  ACCUMULATOR |  93        |
-      |  230          |  230           |  20000  |  NONE        |  0         |
-      |  200          |  200           |  20000  |  NONE        |  0         |
-      |  220          |  220           |  20000  |  NONE        |  0         |
-      |  205          |  205           |  20000  |  NONE        |  0         |
-      |  215          |  215           |  20000  |  NONE        |  0         |
+      |  120          |  120           |  0.305  |  ACCUMULATOR |  105       |
+      |  160          |  160           |  0.305  |  ACCUMULATOR |  104       |
+      |  190          |  190           |  0.305  |  ACCUMULATOR |  93        |
+      |  230          |  230           |  0.305  |  NONE        |  0         |
+      |  200          |  200           |  0.305  |  NONE        |  0         |
+      |  220          |  220           |  0.305  |  NONE        |  0         |
+      |  205          |  205           |  0.305  |  NONE        |  0         |
+      |  215          |  215           |  0.305  |  NONE        |  0         |

--- a/firmware/brake/kia_soul_petrol/tests/features/step_definitions/receiving_messages.cpp
+++ b/firmware/brake/kia_soul_petrol/tests/features/step_definitions/receiving_messages.cpp
@@ -70,7 +70,7 @@ WHEN("^a fault report is received$")
 
 WHEN("^the brake pedal command (.*) is received$")
 {
-    REGEX_PARAM(int, command);
+    REGEX_PARAM(float, command);
 
     oscc_brake_command_s * brake_command =
         (oscc_brake_command_s *) g_mock_mcp_can_read_msg_buf_buf;

--- a/firmware/brake/kia_soul_petrol/tests/property/Cargo.toml
+++ b/firmware/brake/kia_soul_petrol/tests/property/Cargo.toml
@@ -11,7 +11,7 @@ lazy_static = "0.2.8"
 rand = "0.3.15"
 
 [build-dependencies]
-bindgen = "0.20"
+bindgen = "0.32.1"
 gcc = "0.3"
 
 [lib]

--- a/firmware/brake/kia_soul_petrol/tests/property/src/tests.rs
+++ b/firmware/brake/kia_soul_petrol/tests/property/src/tests.rs
@@ -56,8 +56,8 @@ impl Arbitrary for oscc_brake_command_s {
     fn arbitrary<G: Gen>(g: &mut G) -> oscc_brake_command_s {
         oscc_brake_command_s {
             magic: [OSCC_MAGIC_BYTE_0 as u8, OSCC_MAGIC_BYTE_1 as u8],
-            pedal_command: u16::arbitrary(g),
-            reserved: [u8::arbitrary(g); 4],
+            pedal_command: f32::arbitrary(g),
+            reserved: [u8::arbitrary(g); 2usize],
         }
     }
 }

--- a/firmware/steering/src/communications.cpp
+++ b/firmware/steering/src/communications.cpp
@@ -140,8 +140,6 @@ static void process_steering_command(
         const uint16_t spoof_value_high = STEPS_PER_VOLT * spoof_voltage_high;
 
         update_steering( spoof_value_high, spoof_value_low );
-
-        g_steering_command_timeout = false;
     }
 }
 

--- a/firmware/steering/src/communications.cpp
+++ b/firmware/steering/src/communications.cpp
@@ -14,6 +14,7 @@
 #include "mcp_can.h"
 #include "steering_control.h"
 #include "oscc_can.h"
+#include "vehicles.h"
 
 
 static void process_rx_frame(
@@ -130,9 +131,31 @@ static void process_steering_command(
         const oscc_steering_command_s * const steering_command =
                 (oscc_steering_command_s *) data;
 
-        update_steering(
-            steering_command->spoof_value_high,
-            steering_command->spoof_value_low );
+        const float clamped_torque = CONSTRAIN(
+            steering_command->torque_command * MAXIMUM_TORQUE_COMMAND,
+            MINIMUM_TORQUE_COMMAND,
+            MAXIMUM_TORQUE_COMMAND);
+
+        float spoof_voltage_low =
+            STEERING_TORQUE_TO_VOLTS_LOW( clamped_torque );
+
+        spoof_voltage_low = CONSTRAIN(
+            spoof_voltage_low,
+            STEERING_SPOOF_LOW_SIGNAL_VOLTAGE_MIN,
+            STEERING_SPOOF_LOW_SIGNAL_VOLTAGE_MAX);
+
+        float spoof_voltage_high =
+            STEERING_TORQUE_TO_VOLTS_HIGH( clamped_torque );
+
+        spoof_voltage_high = CONSTRAIN(
+            spoof_voltage_high,
+            STEERING_SPOOF_HIGH_SIGNAL_VOLTAGE_MIN,
+            STEERING_SPOOF_HIGH_SIGNAL_VOLTAGE_MAX);
+
+        const uint16_t spoof_value_low = STEPS_PER_VOLT * spoof_voltage_low;
+        const uint16_t spoof_value_high = STEPS_PER_VOLT * spoof_voltage_high;
+
+        update_steering( spoof_value_high, spoof_value_low );
 
         g_steering_command_timeout = false;
     }

--- a/firmware/steering/tests/features/receiving_messages.feature
+++ b/firmware/steering/tests/features/receiving_messages.feature
@@ -32,31 +32,31 @@ Feature: Receiving commands
   Scenario Outline: Spoof value sent from application
     Given steering control is enabled
 
-    When a command is received with spoof values <high> and <low>
+    When a command is received with request value <value>
 
     Then <high> should be sent to DAC A
     And <low> should be sent to DAC B
 
     Examples:
-      | high  | low    |
-      |  3440 |  656  |
-      |  2500 |  1500  |
-      |  2000 |  2000  |
-      |  1500 |  2500  |
-      |  738  |  3358  |
+      | value   | high  | low   |
+      | -1      | 3440  | 656   |
+      | -0.3435 | 2500  | 1475  |
+      | 0       | 1982  | 1957  |
+      | 0.3435  | 1464  | 2440  |
+      | 1       | 738   | 3358  |
 
 
   Scenario Outline: Spoof value sent from application outside valid range
     Given steering control is enabled
 
-    When a command is received with spoof values <high> and <low>
+    When a command is received with request value <value>
 
     Then <high_clamped> should be sent to DAC A
     And <low_clamped> should be sent to DAC B
 
     Examples:
-      | high  | low   | high_clamped | low_clamped |
-      |  4000 |  0    | 3440         |  656        |
-      |  3500 |  500  | 3440         |  656        |
-      |  500  |  3500 | 738          |  3358       |
-      |  0    |  4000 | 738          |  3358       |
+      | value | high_clamped | low_clamped |
+      | -15   | 3440         |  656        |
+      | -1.1  | 3440         |  656        |
+      | 1.1   | 738          |  3358       |
+      | 15    | 738          |  3358       |

--- a/firmware/steering/tests/features/step_definitions/receiving_messages.cpp
+++ b/firmware/steering/tests/features/step_definitions/receiving_messages.cpp
@@ -43,10 +43,9 @@ WHEN("^a fault report is received$")
 }
 
 
-WHEN("^a command is received with spoof values (.*) and (.*)$")
+WHEN("^a command is received with request value (.*)$")
 {
-    REGEX_PARAM(uint16_t, high);
-    REGEX_PARAM(uint16_t, low);
+    REGEX_PARAM(float, request_value);
 
     g_mock_mcp_can_check_receive_return = CAN_MSGAVAIL;
     g_mock_mcp_can_read_msg_buf_id = OSCC_STEERING_COMMAND_CAN_ID;
@@ -57,12 +56,7 @@ WHEN("^a command is received with spoof values (.*) and (.*)$")
 
     steering_command->magic[0] = OSCC_MAGIC_BYTE_0;
     steering_command->magic[1] = OSCC_MAGIC_BYTE_1;
-    steering_command->spoof_value_high = high;
-    steering_command->spoof_value_low = low;
+    steering_command->torque_command = request_value;
 
     check_for_incoming_message();
-
-    update_steering(
-        steering_command->spoof_value_high,
-        steering_command->spoof_value_low);
 }

--- a/firmware/steering/tests/property/Cargo.toml
+++ b/firmware/steering/tests/property/Cargo.toml
@@ -10,7 +10,7 @@ quickcheck = "0.4.1"
 rand = "0.3.15"
 
 [build-dependencies]
-bindgen = "0.25.0"
+bindgen = "0.32.1"
 gcc = "0.3.51"
 
 [lib]

--- a/firmware/steering/tests/property/build.rs
+++ b/firmware/steering/tests/property/build.rs
@@ -57,6 +57,8 @@ fn main() {
         .whitelisted_var("STEERING_SPOOF_LOW_SIGNAL_RANGE_MAX")
         .whitelisted_var("STEERING_SPOOF_HIGH_SIGNAL_RANGE_MIN")
         .whitelisted_var("STEERING_SPOOF_HIGH_SIGNAL_RANGE_MAX")
+        .whitelisted_var("MINIMUM_TORQUE_COMMAND")
+        .whitelisted_var("MAXIMUM_TORQUE_COMMAND")
         .whitelisted_var("CAN_STANDARD")
         .whitelisted_var("CAN_MSGAVAIL")
         .whitelisted_type("oscc_steering_enable_s")

--- a/firmware/steering/tests/property/src/tests.rs
+++ b/firmware/steering/tests/property/src/tests.rs
@@ -60,8 +60,7 @@ impl Arbitrary for oscc_steering_command_s {
     fn arbitrary<G: Gen>(g: &mut G) -> oscc_steering_command_s {
         oscc_steering_command_s {
             magic: [OSCC_MAGIC_BYTE_0 as u8, OSCC_MAGIC_BYTE_1 as u8],
-            spoof_value_low: u16::arbitrary(g),
-            spoof_value_high: u16::arbitrary(g),
+            torque_command: f32::arbitrary(g),
             reserved: [u8::arbitrary(g); 2],
         }
     }
@@ -171,8 +170,7 @@ fn check_process_disable_command() {
 /// the steering firmware should send requested spoof values
 /// upon recieving a steering command message
 fn prop_output_accurate_spoofs(mut steering_command_msg: oscc_steering_command_s) -> TestResult {
-    steering_command_msg.spoof_value_low = rand::thread_rng().gen_range(STEERING_SPOOF_LOW_SIGNAL_RANGE_MIN as u16, STEERING_SPOOF_LOW_SIGNAL_RANGE_MAX as u16);
-    steering_command_msg.spoof_value_high = rand::thread_rng().gen_range(STEERING_SPOOF_HIGH_SIGNAL_RANGE_MIN as u16, STEERING_SPOOF_HIGH_SIGNAL_RANGE_MAX as u16);
+    steering_command_msg.torque_command = rand::thread_rng().gen_range(0f32,1f32);
     unsafe {
         g_steering_control_state.enabled = true;
 
@@ -182,9 +180,10 @@ fn prop_output_accurate_spoofs(mut steering_command_msg: oscc_steering_command_s
 
         check_for_incoming_message();
 
-        TestResult::from_bool(g_mock_dac_output_b ==                                steering_command_msg.spoof_value_low &&
-            g_mock_dac_output_a ==
-            steering_command_msg.spoof_value_high )
+        TestResult::from_bool(g_mock_dac_output_b >= STEERING_SPOOF_LOW_SIGNAL_RANGE_MIN as u16 &&
+                              g_mock_dac_output_b <= STEERING_SPOOF_LOW_SIGNAL_RANGE_MAX as u16 &&
+                              g_mock_dac_output_a >= STEERING_SPOOF_HIGH_SIGNAL_RANGE_MIN as u16 &&
+                              g_mock_dac_output_a <= STEERING_SPOOF_HIGH_SIGNAL_RANGE_MAX as u16 )
     }
 }
 
@@ -200,14 +199,8 @@ fn check_output_accurate_spoofs() {
 /// upon recieving a steering command message
 fn prop_output_constrained_spoofs(steering_command_msg: oscc_steering_command_s) -> TestResult {
     unsafe {
-        if (steering_command_msg.spoof_value_low >=
-            STEERING_SPOOF_LOW_SIGNAL_RANGE_MIN as u16 &&
-            steering_command_msg.spoof_value_low <=
-            STEERING_SPOOF_LOW_SIGNAL_RANGE_MAX as u16) ||
-            (steering_command_msg.spoof_value_high >=
-            STEERING_SPOOF_HIGH_SIGNAL_RANGE_MIN as u16 &&
-            steering_command_msg.spoof_value_high <=
-            STEERING_SPOOF_HIGH_SIGNAL_RANGE_MAX as u16)
+        if steering_command_msg.torque_command >= MINIMUM_TORQUE_COMMAND as f32 &&
+            steering_command_msg.torque_command <= MAXIMUM_TORQUE_COMMAND as f32
         {
             return TestResult::discard();
         }

--- a/firmware/throttle/src/communications.cpp
+++ b/firmware/throttle/src/communications.cpp
@@ -138,8 +138,6 @@ static void process_throttle_command(
         const uint16_t spoof_value_high = STEPS_PER_VOLT * spoof_voltage_high;
 
         update_throttle( spoof_value_high, spoof_value_low );
-
-        g_throttle_command_timeout = false;
     }
 }
 

--- a/firmware/throttle/src/communications.cpp
+++ b/firmware/throttle/src/communications.cpp
@@ -14,6 +14,7 @@
 #include "mcp_can.h"
 #include "oscc_can.h"
 #include "throttle_control.h"
+#include "vehicles.h"
 
 
 static void process_rx_frame(
@@ -130,9 +131,29 @@ static void process_throttle_command(
         const oscc_throttle_command_s * const throttle_command =
                 (oscc_throttle_command_s *) data;
 
-        update_throttle(
-            throttle_command->spoof_value_high,
-            throttle_command->spoof_value_low );
+        const float clamped_position = CONSTRAIN(
+            throttle_command->torque_request,
+            MINIMUM_THROTTLE_COMMAND,
+            MAXIMUM_THROTTLE_COMMAND);
+
+        float spoof_voltage_low = THROTTLE_POSITION_TO_VOLTS_LOW( clamped_position );
+
+        spoof_voltage_low = CONSTRAIN(
+            spoof_voltage_low,
+            THROTTLE_SPOOF_LOW_SIGNAL_VOLTAGE_MIN,
+            THROTTLE_SPOOF_LOW_SIGNAL_VOLTAGE_MAX);
+
+        float spoof_voltage_high = THROTTLE_POSITION_TO_VOLTS_HIGH( clamped_position );
+
+        spoof_voltage_high = CONSTRAIN(
+            spoof_voltage_high,
+            THROTTLE_SPOOF_HIGH_SIGNAL_VOLTAGE_MIN,
+            THROTTLE_SPOOF_HIGH_SIGNAL_VOLTAGE_MAX);
+
+        const uint16_t spoof_value_low = STEPS_PER_VOLT * spoof_voltage_low;
+        const uint16_t spoof_value_high = STEPS_PER_VOLT * spoof_voltage_high;
+
+        update_throttle( spoof_value_high, spoof_value_low );
 
         g_throttle_command_timeout = false;
     }

--- a/firmware/throttle/tests/features/receiving_messages.feature
+++ b/firmware/throttle/tests/features/receiving_messages.feature
@@ -32,34 +32,33 @@ Feature: Receiving commands
   Scenario Outline: Spoof value sent from application
     Given throttle control is enabled
 
-    When a command is received with spoof values <high> and <low>
+    When a command is received with request value <value>
 
     Then <high> should be sent to DAC A
     And <low> should be sent to DAC B
 
     Examples:
-      | high   | low    |
-      |  3358  |  328   |
-      |  3000  |  500   |
-      |  2500  |  1000  |
-      |  2000  |  1500  |
-      |  1500  |  1638  |
-      |  1000  |  1638  |
-      |  656   |  1638  |
-      |  573   |  1638  |
+      | value |  high  |  low   |
+      | 1     |  3358  |  1638  |
+      | 0.8   |  2801  |  1359  |
+      | 0.6   |  2244  |  1081  |
+      | 0.5   |  1966  |  942   |
+      | 0.4   |  1687  |  802   |
+      | 0.2   |  1130  |  524   |
+      | 0     |  573   |  245   |
 
 
   Scenario Outline: Spoof value sent from application outside valid range
     Given throttle control is enabled
 
-    When a command is received with spoof values <high> and <low>
+    When a command is received with request value <value>
 
     Then <high_clamped> should be sent to DAC A
     And <low_clamped> should be sent to DAC B
 
     Examples:
-      | high  | low   | high_clamped | low_clamped |
-      |  4000 |  0    | 3358         |  245        |
-      |  3500 |  500  | 3358         |  500        |
-      |  580  |  3500 | 580          |  1638       |
-      |  500  |  4000 | 573          |  1638       |
+      | value | high_clamped | low_clamped |
+      |  5    | 3358         |  1638       |
+      |  1.1  | 3358         |  1638       |
+      |  -0.1 | 573          |  245        |
+      |  -5   | 573          |  245        |

--- a/firmware/throttle/tests/features/step_definitions/receiving_messages.cpp
+++ b/firmware/throttle/tests/features/step_definitions/receiving_messages.cpp
@@ -43,10 +43,9 @@ WHEN("^a fault report is received$")
 }
 
 
-WHEN("^a command is received with spoof values (.*) and (.*)$")
+WHEN("^a command is received with request value (.*)$")
 {
-    REGEX_PARAM(uint16_t, high);
-    REGEX_PARAM(uint16_t, low);
+    REGEX_PARAM(float, request_value);
 
     g_mock_mcp_can_check_receive_return = CAN_MSGAVAIL;
     g_mock_mcp_can_read_msg_buf_id = OSCC_THROTTLE_COMMAND_CAN_ID;
@@ -56,12 +55,7 @@ WHEN("^a command is received with spoof values (.*) and (.*)$")
 
     throttle_command->magic[0] = OSCC_MAGIC_BYTE_0;
     throttle_command->magic[1] = OSCC_MAGIC_BYTE_1;
-    throttle_command->spoof_value_high = high;
-    throttle_command->spoof_value_low = low;
+    throttle_command->torque_request = request_value;
 
     check_for_incoming_message();
-
-    update_throttle(
-        throttle_command->spoof_value_high,
-        throttle_command->spoof_value_low);
 }

--- a/firmware/throttle/tests/property/Cargo.toml
+++ b/firmware/throttle/tests/property/Cargo.toml
@@ -10,7 +10,7 @@ quickcheck = "0.4.1"
 rand = "0.3.15"
 
 [build-dependencies]
-bindgen = "0.25.0"
+bindgen = "0.32.1"
 gcc = "0.3.51"
 
 [lib]

--- a/firmware/throttle/tests/property/build.rs
+++ b/firmware/throttle/tests/property/build.rs
@@ -54,6 +54,8 @@ fn main() {
         .whitelisted_var("OSCC_THROTTLE_REPORT_PUBLISH_INTERVAL_IN_MSEC")
         .whitelisted_var("CAN_MSGAVAIL")
         .whitelisted_var("CAN_STANDARD")
+        .whitelisted_var("MAXIMUM_THROTTLE_COMMAND")
+        .whitelisted_var("MINIMUM_THROTTLE_COMMAND")
         .whitelisted_var("THROTTLE_SPOOF_LOW_SIGNAL_RANGE_MIN")
         .whitelisted_var("THROTTLE_SPOOF_LOW_SIGNAL_RANGE_MAX")
         .whitelisted_var("THROTTLE_SPOOF_HIGH_SIGNAL_RANGE_MIN")

--- a/firmware/throttle/tests/property/src/tests.rs
+++ b/firmware/throttle/tests/property/src/tests.rs
@@ -58,11 +58,10 @@ impl Arbitrary for oscc_throttle_report_s {
 
 impl Arbitrary for oscc_throttle_command_s {
     fn arbitrary<G: Gen>(g: &mut G) -> oscc_throttle_command_s {
-        oscc_throttle_command_s {
+        oscc_throttle_command_s{
             magic: [OSCC_MAGIC_BYTE_0 as u8, OSCC_MAGIC_BYTE_1 as u8],
-            spoof_value_low: u16::arbitrary(g),
-            spoof_value_high: u16::arbitrary(g),
-            reserved: [u8::arbitrary(g); 2],
+            torque_request: f32::arbitrary(g),
+            reserved: [u8::arbitrary(g); 2usize],
         }
     }
 }
@@ -171,12 +170,8 @@ fn check_process_disable_command() {
 /// the throttle firmware should send requested spoof values
 /// upon recieving a throttle command message
 fn prop_output_accurate_spoofs(mut throttle_command_msg: oscc_throttle_command_s) -> TestResult {
-    throttle_command_msg.spoof_value_low =
-        rand::thread_rng().gen_range(THROTTLE_SPOOF_LOW_SIGNAL_RANGE_MIN as u16,
-                                     THROTTLE_SPOOF_LOW_SIGNAL_RANGE_MAX as u16);
-    throttle_command_msg.spoof_value_high =
-        rand::thread_rng().gen_range(THROTTLE_SPOOF_HIGH_SIGNAL_RANGE_MIN as u16,
-                                     THROTTLE_SPOOF_HIGH_SIGNAL_RANGE_MAX as u16);
+    throttle_command_msg.torque_request = rand::thread_rng().gen_range(0f32, 1f32);
+
     unsafe {
         g_throttle_control_state.enabled = true;
 
@@ -186,8 +181,10 @@ fn prop_output_accurate_spoofs(mut throttle_command_msg: oscc_throttle_command_s
 
         check_for_incoming_message();
 
-        TestResult::from_bool(g_mock_dac_output_b == throttle_command_msg.spoof_value_low &&
-                              g_mock_dac_output_a == throttle_command_msg.spoof_value_high)
+        TestResult::from_bool(g_mock_dac_output_a >= THROTTLE_SPOOF_HIGH_SIGNAL_RANGE_MIN as u16 &&
+                              g_mock_dac_output_a <= THROTTLE_SPOOF_HIGH_SIGNAL_RANGE_MAX as u16 &&
+                              g_mock_dac_output_b >= THROTTLE_SPOOF_LOW_SIGNAL_RANGE_MIN as u16 &&
+                              g_mock_dac_output_b <= THROTTLE_SPOOF_LOW_SIGNAL_RANGE_MAX as u16)
     }
 }
 
@@ -203,10 +200,8 @@ fn check_output_accurate_spoofs() {
 /// upon recieving a throttle command message
 fn prop_output_constrained_spoofs(throttle_command_msg: oscc_throttle_command_s) -> TestResult {
     unsafe {
-        if (throttle_command_msg.spoof_value_low >= THROTTLE_SPOOF_LOW_SIGNAL_RANGE_MIN as u16 &&
-            throttle_command_msg.spoof_value_low <= THROTTLE_SPOOF_LOW_SIGNAL_RANGE_MAX as u16) ||
-           (throttle_command_msg.spoof_value_high >= THROTTLE_SPOOF_HIGH_SIGNAL_RANGE_MIN as u16 &&
-            throttle_command_msg.spoof_value_high <= THROTTLE_SPOOF_HIGH_SIGNAL_RANGE_MAX as u16) {
+        if  throttle_command_msg.torque_request >= MINIMUM_THROTTLE_COMMAND as f32 &&
+            throttle_command_msg.torque_request <= MAXIMUM_THROTTLE_COMMAND as f32 {
             return TestResult::discard();
         }
 


### PR DESCRIPTION
This PR Depends on #229 Add CAN Filtering please make sure that PR has been approved and merged before this one.

This pull request changes the CAN messages shipped across the wire so that the API can be agnostic to the Vehicle and Firmware versions which will allow a user to use the same API regardless of vehicle and firmware versions as long as they are >= this version released.