### PR TITLE
Support variable arity for DEBUG fns

### DIFF
--- a/firmware/common/include/debug.h
+++ b/firmware/common/include/debug.h
@@ -14,11 +14,11 @@
 
 #ifdef DEBUG
     #warning "DEBUG defined"
-    #define DEBUG_PRINT(x) Serial.print(x)
-    #define DEBUG_PRINTLN(x) Serial.println(x)
+    #define DEBUG_PRINT(...) Serial.print(__VA_ARGS__)
+    #define DEBUG_PRINTLN(...) Serial.println(__VA_ARGS__)
 #else
-    #define DEBUG_PRINT(x)
-    #define DEBUG_PRINTLN(x)
+    #define DEBUG_PRINT(...)
+    #define DEBUG_PRINTLN(...)
 #endif
 
 


### PR DESCRIPTION
The Arduino Serial functions are variadic and accept optional format
arguments, but our wrappers for printing debug messages have a fixed
arity of 1. This commit updates the DEBUG_ macros to forward variadic
args to the underlying Serial functions to expose the richer
functionality.