### PR TITLE
Fix swapped voltages

### DIFF
--- a/firmware/brake/kia_soul_ev/src/brake_control.cpp
+++ b/firmware/brake/kia_soul_ev/src/brake_control.cpp
@@ -158,8 +158,8 @@ void enable_control( void )
         prevent_signal_discontinuity(
             g_dac,
             num_samples,
-            PIN_BRAKE_PEDAL_POSITION_SENSOR_HIGH,
-            PIN_BRAKE_PEDAL_POSITION_SENSOR_LOW );
+            PIN_BRAKE_PEDAL_POSITION_SENSOR_LOW,
+            PIN_BRAKE_PEDAL_POSITION_SENSOR_HIGH );
 
         cli();
         digitalWrite( PIN_SPOOF_ENABLE, HIGH );
@@ -181,8 +181,8 @@ void disable_control( void )
         prevent_signal_discontinuity(
             g_dac,
             num_samples,
-            PIN_BRAKE_PEDAL_POSITION_SENSOR_HIGH,
-            PIN_BRAKE_PEDAL_POSITION_SENSOR_LOW );
+            PIN_BRAKE_PEDAL_POSITION_SENSOR_LOW,
+            PIN_BRAKE_PEDAL_POSITION_SENSOR_HIGH );
 
         cli();
         digitalWrite( PIN_SPOOF_ENABLE, LOW );

--- a/firmware/throttle/src/throttle_control.cpp
+++ b/firmware/throttle/src/throttle_control.cpp
@@ -144,8 +144,8 @@ void enable_control( void )
         prevent_signal_discontinuity(
             g_dac,
             num_samples,
-            PIN_ACCELERATOR_POSITION_SENSOR_HIGH,
-            PIN_ACCELERATOR_POSITION_SENSOR_LOW );
+            PIN_ACCELERATOR_POSITION_SENSOR_LOW,
+            PIN_ACCELERATOR_POSITION_SENSOR_HIGH );
 
         cli();
         digitalWrite( PIN_SPOOF_ENABLE, HIGH );
@@ -167,8 +167,8 @@ void disable_control( void )
         prevent_signal_discontinuity(
             g_dac,
             num_samples,
-            PIN_ACCELERATOR_POSITION_SENSOR_HIGH,
-            PIN_ACCELERATOR_POSITION_SENSOR_LOW );
+            PIN_ACCELERATOR_POSITION_SENSOR_LOW,
+            PIN_ACCELERATOR_POSITION_SENSOR_HIGH );
 
         cli();
         digitalWrite( PIN_SPOOF_ENABLE, LOW );


### PR DESCRIPTION
This pull request swaps the enable and disable DAC A and B pins in throttle and kia soul ev brake modules so that when OSCC enables the pins are set to the correct voltages and don't cause faults which was found while validating PR #217.