### PR TITLE
Disable Soul EV brake light on control disable

### DIFF
--- a/firmware/brake/kia_soul_ev/src/brake_control.cpp
+++ b/firmware/brake/kia_soul_ev/src/brake_control.cpp
@@ -150,6 +150,7 @@ void disable_control( void )
 
         cli();
         digitalWrite( PIN_SPOOF_ENABLE, LOW );
+        digitalWrite( PIN_BRAKE_LIGHT_ENABLE, LOW );
         sei();
 
         g_brake_control_state.enabled = false;


### PR DESCRIPTION
If OSCC was applying the brakes and had the brake light enabled when
OSCC was disabled, control would be disabled but the brake light would
not be explicitly turned off. This commit adds an explicit disable to
the disable_control() function to ensure consistent behavior with the
brake light.