### PR TITLE
brake/petrol: Log accumulator state

### DIFF
--- a/firmware/brake/kia_soul_petrol/src/accumulator.cpp
+++ b/firmware/brake/kia_soul_petrol/src/accumulator.cpp
@@ -53,12 +53,49 @@ void accumulator_maintain_pressure( void )
 {
     float pressure = accumulator_read_pressure( );
 
+#ifdef DEBUG
+    static uint8_t accumulator_active = 0;
+    static unsigned long last_accum_log = 0;
+
+    if(last_accum_log < (millis() - 1000)) {
+        DEBUG_PRINT("[accumulator] current pressure: ");
+        DEBUG_PRINT(pressure);
+        DEBUG_PRINTLN(" dbar");
+        last_accum_log = millis();
+    }
+#endif // DEBUG
+
     if ( pressure <= BRAKE_ACCUMULATOR_PRESSURE_MIN_IN_DECIBARS )
     {
+#ifdef DEBUG
+        if(!accumulator_active) {
+            DEBUG_PRINT("[accumulator] current pressure (");
+            DEBUG_PRINT(pressure);
+            DEBUG_PRINT(") below min (");
+            DEBUG_PRINT(BRAKE_ACCUMULATOR_PRESSURE_MIN_IN_DECIBARS);
+            DEBUG_PRINTLN(")");
+            DEBUG_PRINTLN("[accumulator] Turning on brake pump");
+            accumulator_active = 1;
+        }
+#endif // DEBUG
+
         accumulator_turn_pump_on( );
     }
     else if ( pressure >= BRAKE_ACCUMULATOR_PRESSURE_MAX_IN_DECIBARS )
     {
+
+#ifdef DEBUG
+        if(accumulator_active) {
+            DEBUG_PRINT("[accumulator] current pressure (");
+            DEBUG_PRINT(pressure);
+            DEBUG_PRINT(") at or above max (");
+            DEBUG_PRINT(BRAKE_ACCUMULATOR_PRESSURE_MAX_IN_DECIBARS);
+            DEBUG_PRINTLN(")");
+            DEBUG_PRINTLN("[accumulator] Turning off brake pump");
+            accumulator_active = 0;
+        }
+#endif // DEBUG
+
         accumulator_turn_pump_off( );
     }
 }

--- a/firmware/brake/kia_soul_petrol/src/brake_control.cpp
+++ b/firmware/brake/kia_soul_petrol/src/brake_control.cpp
@@ -490,6 +490,7 @@ static void pressure_startup_check( void )
 
 static void pump_startup_check( void )
 {
+    DEBUG_PRINTLN("[brake control] Running startup check\n");
     accumulator_turn_pump_on();
     delay(250);
 
@@ -502,7 +503,7 @@ static void pump_startup_check( void )
     {
         g_brake_control_state.startup_pump_motor_check_error = true;
 
-        DEBUG_PRINTLN( "Startup pump motor error" );
+        DEBUG_PRINTLN( "[brake control] Startup pump motor error" );
     }
     else
     {


### PR DESCRIPTION
This commit adds debug logging for the petrol brake module accumulator
functions. The accumulator pressure is reported every second and
messages are logged when the pump is enabled and disabled.