### PR TITLE
Add NULL firmware implementation

### DIFF
--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -65,6 +65,7 @@ else()
 
     add_subdirectory(brake)
     add_subdirectory(can_gateway)
+    add_subdirectory(null)
     add_subdirectory(steering)
     add_subdirectory(throttle)
 
@@ -73,6 +74,7 @@ else()
         DEPENDS
         brake-upload
         can-gateway-upload
+        null
         steering-upload
         throttle-upload)
 endif()

--- a/firmware/cmake/OsccFirmware.cmake
+++ b/firmware/cmake/OsccFirmware.cmake
@@ -22,6 +22,9 @@ set(SERIAL_BAUD_STEERING "115200" CACHE STRING "Serial baud rate of the steering
 set(SERIAL_PORT_THROTTLE "/dev/ttyACM0" CACHE STRING "Serial port of the throttle module")
 set(SERIAL_BAUD_THROTTLE "115200" CACHE STRING "Serial baud rate of the throttle module")
 
+set(SERIAL_PORT_NULL "/dev/ttyACM0" CACHE STRING "Serial port of the NULL module")
+set(SERIAL_BAUD_NULL "115200" CACHE STRING "Serial baud rate of the NULL module")
+
 if(DEBUG)
     add_definitions(-DDEBUG)
 endif()

--- a/firmware/null/CMakeLists.txt
+++ b/firmware/null/CMakeLists.txt
@@ -1,0 +1,10 @@
+project(null)
+
+set(ARDUINO_DEFAULT_BOARD uno)
+SET(ARDUINO_DEFAULT_PORT ${SERIAL_PORT_NULL})
+set(ARDUINO_DEFAULT_BAUDRATE ${SERIAL_BAUD_NULL})
+
+generate_arduino_firmware(
+    null
+    SRCS
+    main.cpp)

--- a/firmware/null/main.cpp
+++ b/firmware/null/main.cpp
@@ -1,0 +1,8 @@
+/**
+ * @file main.cpp
+ * NULL Implementation
+ */
+int main( void )
+{
+    while( true ) { }
+}


### PR DESCRIPTION
Prior to this commit there was no clear firmware solution for disabling one or a subset of OSCC modules. This commit represents the addition of a NULL firmware implementation such that any combination of modules can be essentially ignored by OSCC. The NULL implementation is build by default and uploaded to any module with the command `make null-upload`.