### PR TITLE
Add ifndef for ATmega32U4 support

### DIFF
--- a/firmware/common/libs/timer/oscc_timer.cpp
+++ b/firmware/common/libs/timer/oscc_timer.cpp
@@ -10,7 +10,9 @@
 
 
 static void (*timer_1_isr)(void);
+#ifndef __AVR_ATmega32U4__
 static void (*timer_2_isr)(void);
+#endif
 
 
 // timer1 interrupt service routine
@@ -19,11 +21,13 @@ ISR(TIMER1_COMPA_vect)
     timer_1_isr( );
 }
 
+#ifndef __AVR_ATmega32U4__
 // timer2 interrupt service routine
 ISR(TIMER2_COMPA_vect)
 {
     timer_2_isr( );
 }
+#endif
 
 
 void timer1_init( float frequency, void (*isr)(void) )
@@ -101,7 +105,7 @@ void timer1_init( float frequency, void (*isr)(void) )
     sei();
 }
 
-
+#ifndef __AVR_ATmega32U4__
 void timer2_init( float frequency, void (*isr)(void) )
 {
     // disable interrupts temporarily
@@ -188,3 +192,4 @@ void timer2_init( float frequency, void (*isr)(void) )
     // re-enable interrupts
     sei();
 }
+#endif

--- a/firmware/common/libs/timer/oscc_timer.h
+++ b/firmware/common/libs/timer/oscc_timer.h
@@ -113,6 +113,7 @@ void timer1_init(
     float frequency,
     void (*isr)(void) );
 
+#ifndef __AVR_ATmega32U4__
 // ****************************************************************************
 // Function:    timer2_init
 //
@@ -131,6 +132,7 @@ void timer1_init(
 void timer2_init(
     float frequency,
     void (*isr)(void) );
+#endif
 
 
 #endif /* _OSCC_TIMER_H_ */


### PR DESCRIPTION
Prior to this commit a build would fail if building for ATmega32U4 chips like
the leonardo arduino. This commit fixes that by wrapping timer2 around an
ifndef for the ATmega32U4.