### PR TITLE
OSCC firmware root dir in serial actuator

### DIFF
--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -60,6 +60,8 @@ else()
 
     project(firmware)
 
+    set(ARDUINO_DEFAULT_BOARD leonardo)
+
     add_subdirectory(brake)
     add_subdirectory(can_gateway)
     add_subdirectory(null)

--- a/firmware/brake/kia_soul_petrol/utils/serial_actuator/CMakeLists.txt
+++ b/firmware/brake/kia_soul_petrol/utils/serial_actuator/CMakeLists.txt
@@ -3,13 +3,13 @@ project(brake-utils-serial-actuator)
 generate_arduino_firmware(
     brake-utils-serial-actuator
     SRCS
-    ${OSCC_FIRMWARE_DIR}/common/libs/arduino_init/arduino_init.cpp
-    ${OSCC_FIRMWARE_DIR}/common/libs/mcp_can/mcp_can.cpp
-    ${OSCC_FIRMWARE_DIR}/common/libs/pid/oscc_pid.cpp
-    ${OSCC_FIRMWARE_DIR}/common/libs/serial/oscc_serial.cpp
-    ${OSCC_FIRMWARE_DIR}/common/libs/can/oscc_can.cpp
-    ${OSCC_FIRMWARE_DIR}/common/libs/timer/oscc_timer.cpp
-    ${OSCC_FIRMWARE_DIR}/common/libs/fault_check/oscc_check.cpp
+    ${OSCC_FIRMWARE_ROOT}/common/libs/arduino_init/arduino_init.cpp
+    ${OSCC_FIRMWARE_ROOT}/common/libs/mcp_can/mcp_can.cpp
+    ${OSCC_FIRMWARE_ROOT}/common/libs/pid/oscc_pid.cpp
+    ${OSCC_FIRMWARE_ROOT}/common/libs/serial/oscc_serial.cpp
+    ${OSCC_FIRMWARE_ROOT}/common/libs/can/oscc_can.cpp
+    ${OSCC_FIRMWARE_ROOT}/common/libs/timer/oscc_timer.cpp
+    ${OSCC_FIRMWARE_ROOT}/common/libs/fault_check/oscc_check.cpp
     ../../src/globals.cpp
     ../../src/accumulator.cpp
     ../../src/helper.cpp
@@ -23,12 +23,12 @@ target_include_directories(
     brake-utils-serial-actuator
     PRIVATE
     ../../include
-    ${OSCC_FIRMWARE_DIR}/common/include
-    ${OSCC_FIRMWARE_DIR}/common/libs/arduino_init
-    ${OSCC_FIRMWARE_DIR}/common/libs/mcp_can
-    ${OSCC_FIRMWARE_DIR}/common/libs/pid
-    ${OSCC_FIRMWARE_DIR}/common/libs/serial
-    ${OSCC_FIRMWARE_DIR}/common/libs/can
-    ${OSCC_FIRMWARE_DIR}/common/libs/timer
-    ${OSCC_FIRMWARE_DIR}/common/libs/fault_check
-    ${OSCC_FIRMWARE_DIR}/../api/include)
+    ${OSCC_FIRMWARE_ROOT}/common/include
+    ${OSCC_FIRMWARE_ROOT}/common/libs/arduino_init
+    ${OSCC_FIRMWARE_ROOT}/common/libs/mcp_can
+    ${OSCC_FIRMWARE_ROOT}/common/libs/pid
+    ${OSCC_FIRMWARE_ROOT}/common/libs/serial
+    ${OSCC_FIRMWARE_ROOT}/common/libs/can
+    ${OSCC_FIRMWARE_ROOT}/common/libs/timer
+    ${OSCC_FIRMWARE_ROOT}/common/libs/fault_check
+    ${OSCC_FIRMWARE_ROOT}/../api/include)

--- a/firmware/brake/kia_soul_petrol/utils/serial_actuator/CMakeLists.txt
+++ b/firmware/brake/kia_soul_petrol/utils/serial_actuator/CMakeLists.txt
@@ -3,13 +3,13 @@ project(brake-utils-serial-actuator)
 generate_arduino_firmware(
     brake-utils-serial-actuator
     SRCS
-    ${CMAKE_SOURCE_DIR}/common/libs/arduino_init/arduino_init.cpp
-    ${CMAKE_SOURCE_DIR}/common/libs/mcp_can/mcp_can.cpp
-    ${CMAKE_SOURCE_DIR}/common/libs/pid/oscc_pid.cpp
-    ${CMAKE_SOURCE_DIR}/common/libs/serial/oscc_serial.cpp
-    ${CMAKE_SOURCE_DIR}/common/libs/can/oscc_can.cpp
-    ${CMAKE_SOURCE_DIR}/common/libs/timer/oscc_timer.cpp
-    ${CMAKE_SOURCE_DIR}/common/libs/fault_check/oscc_check.cpp
+    ${OSCC_FIRMWARE_DIR}/common/libs/arduino_init/arduino_init.cpp
+    ${OSCC_FIRMWARE_DIR}/common/libs/mcp_can/mcp_can.cpp
+    ${OSCC_FIRMWARE_DIR}/common/libs/pid/oscc_pid.cpp
+    ${OSCC_FIRMWARE_DIR}/common/libs/serial/oscc_serial.cpp
+    ${OSCC_FIRMWARE_DIR}/common/libs/can/oscc_can.cpp
+    ${OSCC_FIRMWARE_DIR}/common/libs/timer/oscc_timer.cpp
+    ${OSCC_FIRMWARE_DIR}/common/libs/fault_check/oscc_check.cpp
     ../../src/globals.cpp
     ../../src/accumulator.cpp
     ../../src/helper.cpp
@@ -23,12 +23,12 @@ target_include_directories(
     brake-utils-serial-actuator
     PRIVATE
     ../../include
-    ${CMAKE_SOURCE_DIR}/common/include
-    ${CMAKE_SOURCE_DIR}/common/libs/arduino_init
-    ${CMAKE_SOURCE_DIR}/common/libs/mcp_can
-    ${CMAKE_SOURCE_DIR}/common/libs/pid
-    ${CMAKE_SOURCE_DIR}/common/libs/serial
-    ${CMAKE_SOURCE_DIR}/common/libs/can
-    ${CMAKE_SOURCE_DIR}/common/libs/timer
-    ${CMAKE_SOURCE_DIR}/common/libs/fault_check
-    ${CMAKE_SOURCE_DIR}/../api/include)
+    ${OSCC_FIRMWARE_DIR}/common/include
+    ${OSCC_FIRMWARE_DIR}/common/libs/arduino_init
+    ${OSCC_FIRMWARE_DIR}/common/libs/mcp_can
+    ${OSCC_FIRMWARE_DIR}/common/libs/pid
+    ${OSCC_FIRMWARE_DIR}/common/libs/serial
+    ${OSCC_FIRMWARE_DIR}/common/libs/can
+    ${OSCC_FIRMWARE_DIR}/common/libs/timer
+    ${OSCC_FIRMWARE_DIR}/common/libs/fault_check
+    ${OSCC_FIRMWARE_DIR}/../api/include)


### PR DESCRIPTION
OSCC_FIRMWARE_DIR was missed in the serial_actuator from #270 This pull request updates the serial_actuator to follow the rest of the OSCC_FIRMWARE_DIR cmake variable.