### PR TITLE
Fix oscc firmware root directory

### DIFF
--- a/firmware/brake/kia_soul_petrol/utils/serial_actuator/CMakeLists.txt
+++ b/firmware/brake/kia_soul_petrol/utils/serial_actuator/CMakeLists.txt
@@ -3,13 +3,13 @@ project(brake-utils-serial-actuator)
 generate_arduino_firmware(
     brake-utils-serial-actuator
     SRCS
-    ${CMAKE_SOURCE_DIR}/common/libs/arduino_init/arduino_init.cpp
-    ${CMAKE_SOURCE_DIR}/common/libs/mcp_can/mcp_can.cpp
-    ${CMAKE_SOURCE_DIR}/common/libs/pid/oscc_pid.cpp
-    ${CMAKE_SOURCE_DIR}/common/libs/serial/oscc_serial.cpp
-    ${CMAKE_SOURCE_DIR}/common/libs/can/oscc_can.cpp
-    ${CMAKE_SOURCE_DIR}/common/libs/timer/oscc_timer.cpp
-    ${CMAKE_SOURCE_DIR}/common/libs/fault_check/oscc_check.cpp
+    ${OSCC_FIRMWARE_ROOT}/common/libs/arduino_init/arduino_init.cpp
+    ${OSCC_FIRMWARE_ROOT}/common/libs/mcp_can/mcp_can.cpp
+    ${OSCC_FIRMWARE_ROOT}/common/libs/pid/oscc_pid.cpp
+    ${OSCC_FIRMWARE_ROOT}/common/libs/serial/oscc_serial.cpp
+    ${OSCC_FIRMWARE_ROOT}/common/libs/can/oscc_can.cpp
+    ${OSCC_FIRMWARE_ROOT}/common/libs/timer/oscc_timer.cpp
+    ${OSCC_FIRMWARE_ROOT}/common/libs/fault_check/oscc_check.cpp
     ../../src/globals.cpp
     ../../src/accumulator.cpp
     ../../src/helper.cpp
@@ -23,12 +23,12 @@ target_include_directories(
     brake-utils-serial-actuator
     PRIVATE
     ../../include
-    ${CMAKE_SOURCE_DIR}/common/include
-    ${CMAKE_SOURCE_DIR}/common/libs/arduino_init
-    ${CMAKE_SOURCE_DIR}/common/libs/mcp_can
-    ${CMAKE_SOURCE_DIR}/common/libs/pid
-    ${CMAKE_SOURCE_DIR}/common/libs/serial
-    ${CMAKE_SOURCE_DIR}/common/libs/can
-    ${CMAKE_SOURCE_DIR}/common/libs/timer
-    ${CMAKE_SOURCE_DIR}/common/libs/fault_check
-    ${CMAKE_SOURCE_DIR}/../api/include)
+    ${OSCC_FIRMWARE_ROOT}/common/include
+    ${OSCC_FIRMWARE_ROOT}/common/libs/arduino_init
+    ${OSCC_FIRMWARE_ROOT}/common/libs/mcp_can
+    ${OSCC_FIRMWARE_ROOT}/common/libs/pid
+    ${OSCC_FIRMWARE_ROOT}/common/libs/serial
+    ${OSCC_FIRMWARE_ROOT}/common/libs/can
+    ${OSCC_FIRMWARE_ROOT}/common/libs/timer
+    ${OSCC_FIRMWARE_ROOT}/common/libs/fault_check
+    ${OSCC_FIRMWARE_ROOT}/../api/include)


### PR DESCRIPTION
Prior to this commit the serial actuator built against the cmake source dir
which is no longer the practice for using the oscc firmware root directory.
This commit fixes that by updating the variable used to oscc firmware root
directory instead.