### PR TITLE
Correct return code check for oscc_close()

### DIFF
--- a/api/src/oscc.c
+++ b/api/src/oscc.c
@@ -107,29 +107,35 @@ oscc_result_t oscc_open( unsigned int channel )
 
 oscc_result_t oscc_close( unsigned int channel )
 {
-    oscc_result_t result = OSCC_ERROR;
+    oscc_result_t ret = OSCC_ERROR;
 
-    if( global_oscc_can_socket < 0 )
+    if( global_oscc_can_socket >= 0 )
     {
         int result = close( global_oscc_can_socket );
 
-        if ( result > 0 )
+        if ( result == 0 )
         {
-            result = OSCC_OK;
+            ret = OSCC_OK;
         }
     }
 
-    if( global_vehicle_can_socket < 0 )
+    if( global_vehicle_can_socket >= 0 )
     {
         int result = close( global_vehicle_can_socket );
 
-        if ( result > 0 )
+        if ( result == 0 && ret == OSCC_OK )
         {
-            result = OSCC_OK;
+            ret = OSCC_OK;
+        }
+        else
+        {
+            // If we were able to close the OSCC CAN socket but failed to close
+            // the OSCC socket, overwrite the return code with an error.
+            ret = OSCC_ERROR;
         }
     }
 
-    return result;
+    return ret;
 }
 
 oscc_result_t oscc_enable( void )

--- a/api/src/oscc.c
+++ b/api/src/oscc.c
@@ -107,7 +107,8 @@ oscc_result_t oscc_open( unsigned int channel )
 
 oscc_result_t oscc_close( unsigned int channel )
 {
-    oscc_result_t ret = OSCC_ERROR;
+    bool closed_channel = false;
+    bool close_errored = false;
 
     if( global_oscc_can_socket >= 0 )
     {
@@ -115,7 +116,11 @@ oscc_result_t oscc_close( unsigned int channel )
 
         if ( result == 0 )
         {
-            ret = OSCC_OK;
+            closed_channel = true;
+        }
+        else
+        {
+            close_errored = true;
         }
     }
 
@@ -123,19 +128,24 @@ oscc_result_t oscc_close( unsigned int channel )
     {
         int result = close( global_vehicle_can_socket );
 
-        if ( result == 0 && ret == OSCC_OK )
+        if ( result == 0 )
         {
-            ret = OSCC_OK;
+            closed_channel = true;
         }
         else
         {
-            // If we were able to close the OSCC CAN socket but failed to close
-            // the OSCC socket, overwrite the return code with an error.
-            ret = OSCC_ERROR;
+            close_errored = true;
         }
     }
 
-    return ret;
+    if ( closed_channel == true && close_errored == false )
+    {
+        return OSCC_OK;
+    }
+    else
+    {
+        return OSCC_ERROR;
+    }
 }
 
 oscc_result_t oscc_enable( void )


### PR DESCRIPTION
In oscc_close() when we were checking if the file descriptors could be
closed the sign check was reversed, and when the socket(s) were closed
the return code assumed that `close()` would return >0 when it returns 0
on success and -1 on error. In addition the variable naming introduced
variable shadowing of the function return code; setting the result
inside of close would instead set the shadowing variable whose value
would be discarded.

This commit resolve these issues by
  1) correcting the sign check to close opened file descriptors
  2) correcting the return code check of close()
  3) removing the variable shadowing to properly return closed values.

Test coverage of this is defined in the HIL property tests. Example tests are as follows:

```rust
extern crate oscc;

use oscc::channel::Channel;

mod close {
    use super::*;

    #[test]
    fn can_close_opened_channel() {
        let mut channel = Channel::open(0).expect("Unable to open OSCC channel");
        channel.close().expect("Unable to close OSCC channel");
    }

    #[test]
    fn errors_when_closing_opened_channel() {
        let mut channel = Channel::open(0).expect("Unable to open OSCC channel");
        channel.close().expect("Unable to close OSCC channel");
        channel.close().expect_err("Somehow managed to close an already closed channel");
    }
}
```