### PR TITLE
Add "getter" functions to unpack OBD-II CAN data

### DIFF
--- a/api/include/oscc.h
+++ b/api/include/oscc.h
@@ -204,4 +204,117 @@ oscc_result_t oscc_subscribe_to_fault_reports( void( *callback )( oscc_fault_rep
 oscc_result_t oscc_subscribe_to_obd_messages( void( *callback )( struct can_frame *frame ) );
 
 
+/**
+ * @brief Set vehicle right rear wheel speed in kph from CAN frame. (kph)
+ *
+ * @param [in] frame - A pointer to \ref struct can_frame that contains the raw CAN data associated
+ * with wheel speed (CAN ID: \ref KIA_SOUL_OBD_WHEEL_SPEED_CAN_ID)
+ *
+ * @param [out] wheel_speed_right_rear - A pointer to double. Set to the unpacked and scaled rear
+ * right wheel speed reported by the vehicle (kph).
+ *
+ * @return:
+ * \li \ref OSCC_OK on successful unpacking.
+ * \li \ref OSCC_ERROR if a parameter is NULL or the CAN frame ID is not
+ * \ref KIA_SOUL_OBD_WHEEL_SPEED_CAN_ID
+ */
+oscc_result_t get_wheel_speed_right_rear(
+    struct can_frame const * const frame,
+    double * wheel_speed_right_rear);
+
+/**
+ * @brief Get vehicle left rear wheel speed in kph from CAN frame. (kph)
+ *
+ * @param [in] frame - A pointer to \ref struct can_frame that contains the raw CAN data associated
+ * with wheel speed (CAN ID: \ref KIA_SOUL_OBD_WHEEL_SPEED_CAN_ID)
+ *
+ * @param [out] wheel_speed_left_rear - A pointer to double. Set to the unpacked and scaled front
+ * left wheel speed reported by the vehicle (kph).
+ *
+ * @return:
+ * \li \ref OSCC_OK on successful unpacking.
+ * \li \ref OSCC_ERROR if a parameter is NULL or the CAN frame ID is not
+ * \ref KIA_SOUL_OBD_WHEEL_SPEED_CAN_ID
+ */
+oscc_result_t get_wheel_speed_left_rear(
+    struct can_frame const * const frame,
+    double * wheel_speed_left_rear);
+
+
+/**
+ * @brief Get vehicle right front wheel speed in kph from CAN frame. (kph)
+ *
+ * @param [in] frame - A pointer to \ref struct can_frame that contains the raw CAN data associated
+ * with wheel speed (CAN ID: \ref KIA_SOUL_OBD_WHEEL_SPEED_CAN_ID)
+ *
+ * @param [out] wheel_speed_right_front - A pointer to double. Set to the unpacked and scaled front
+ * right wheel speed reported by the vehicle (kph).
+ *
+ * @return:
+ * \li \ref OSCC_OK on successful unpacking.
+ * \li \ref OSCC_ERROR if a parameter is NULL or the CAN frame ID is not
+ * \ref KIA_SOUL_OBD_WHEEL_SPEED_CAN_ID
+ */
+oscc_result_t get_wheel_speed_right_front(
+    struct can_frame const * const frame,
+    double * wheel_speed_right_front);
+
+
+/**
+ * @brief Get vehicle left front wheel speed in kph from CAN frame. (kph)
+ *
+ * @param [in] frame - A pointer to \ref struct can_frame that contains the raw CAN data associated
+ * with wheel speed (CAN ID: \ref KIA_SOUL_OBD_WHEEL_SPEED_CAN_ID)
+ *
+ * @param [out] wheel_speed_left_front - A pointer to double. Set to the unpacked and scaled rear
+ * left wheel speed reported by the vehicle (kph).
+ *
+ * @return:
+ * \li \ref OSCC_OK on successful unpacking.
+ * \li \ref OSCC_ERROR if a parameter is NULL or the CAN frame ID is not
+ * \ref KIA_SOUL_OBD_WHEEL_SPEED_CAN_ID
+ */
+oscc_result_t get_wheel_speed_left_front(
+    struct can_frame const * const frame,
+    double * wheel_speed_left_front);
+
+
+/**
+ * @brief Get vehicle steering wheel angle from CAN frame. (degrees)
+ *
+ * @param [in] frame - A pointer to \ref struct can_frame that contains the raw CAN data associated
+ * with steering wheel angle (CAN ID: \ref KIA_SOUL_OBD_STEERING_WHEEL_ANGLE_CAN_ID)
+ *
+ * @param [out] steering_wheel_angle - A pointer to double. Value is set to the unpacked and scaled
+ * steering wheel angle reported by the vehicle (degrees).
+ *
+ * @return:
+ * \li \ref OSCC_OK on successful unpacking.
+ * \li \ref OSCC_ERROR if a parameter is NULL or the CAN frame ID is not
+ * \ref KIA_SOUL_OBD_STEERING_WHEEL_ANGLE_CAN_ID
+ */
+oscc_result_t get_steering_wheel_angle(
+    struct can_frame const * const frame,
+    double * steering_wheel_angle);
+
+
+/**
+ * @brief Get vehicle brake pressure from CAN frame. (bar)
+ *
+ * @param [in] frame - A pointer to \ref struct can_frame that contains the raw CAN data associated
+ * with brake pressure (CAN ID: \ref KIA_SOUL_OBD_BRAKE_PRESSURE_CAN_ID)
+ *
+ * @param [out] brake_pressure - A pointer to double. Set to the unpacked and scaled brake pressure
+ * reported by the vehicle (bar).
+ *
+ * @return:
+ * \li \ref OSCC_OK on successful unpacking.
+ * \li \ref OSCC_ERROR if a parameter is NULL or the CAN frame ID is not
+ * \ref KIA_SOUL_OBD_BRAKE_PRESSURE_CAN_ID
+ */
+oscc_result_t get_brake_pressure(
+    struct can_frame const * const frame,
+    double * brake_pressure);
+
+
 #endif /* _OSCC_H */

--- a/api/include/vehicles/kia_niro.h
+++ b/api/include/vehicles/kia_niro.h
@@ -63,7 +63,7 @@
 
 /**
  * @brief Steering wheel angle message data.
- *
+ * @warn Deprecated. Use \ref get_steering_wheel_angle instead.
  */
 typedef struct
 {
@@ -74,7 +74,12 @@ typedef struct
 
 /**
  * @brief Wheel speed message data.
- *
+ * @warn Deprecated.
+ * @warn Does not reflect CAN message data. Use the following functions instead:
+ * \li \ref get_wheel_speed_right_rear
+ * \li \ref get_wheel_speed_left_rear
+ * \li \ref get_wheel_speed_right_front
+ * \li \ref get_wheel_speed_left_front
  */
 typedef struct
 {
@@ -97,7 +102,8 @@ typedef struct
 
 /**
  * @brief Brake pressure message data.
- *
+ * @warn Deprecated.
+ * @warn Does not reflect CAN message data. Use \ref get_wheel_brake_pressure instead.
  */
 typedef struct
 {

--- a/api/include/vehicles/kia_soul_ev.h
+++ b/api/include/vehicles/kia_soul_ev.h
@@ -57,7 +57,7 @@
 
 /**
  * @brief Steering wheel angle message data.
- *
+ * @warn Deprecated. Use \ref get_steering_wheel_angle instead.
  */
 typedef struct
 {
@@ -68,7 +68,12 @@ typedef struct
 
 /**
  * @brief Wheel speed message data.
- *
+ * @warn Deprecated.
+ * @warn Does not reflect CAN message data. Use the following functions instead:
+ * \li \ref get_wheel_speed_right_rear
+ * \li \ref get_wheel_speed_left_rear
+ * \li \ref get_wheel_speed_right_front
+ * \li \ref get_wheel_speed_left_front
  */
 typedef struct
 {
@@ -83,7 +88,8 @@ typedef struct
 
 /**
  * @brief Brake pressure message data.
- *
+ * @warn Deprecated.
+ * @warn Does not reflect CAN message data. Use \ref get_wheel_brake_pressure instead.
  */
 typedef struct
 {

--- a/api/include/vehicles/kia_soul_petrol.h
+++ b/api/include/vehicles/kia_soul_petrol.h
@@ -57,7 +57,7 @@
 
 /**
  * @brief Steering wheel angle message data.
- *
+ * @warn Deprecated. Use \ref get_steering_wheel_angle instead.
  */
 typedef struct
 {
@@ -68,7 +68,12 @@ typedef struct
 
 /**
  * @brief Wheel speed message data.
- *
+ * @warn Deprecated.
+ * @warn Does not reflect CAN message data. Use the following functions instead:
+ * \li \ref get_wheel_speed_right_rear
+ * \li \ref get_wheel_speed_left_rear
+ * \li \ref get_wheel_speed_right_front
+ * \li \ref get_wheel_speed_left_front
  */
 typedef struct
 {
@@ -83,7 +88,8 @@ typedef struct
 
 /**
  * @brief Brake pressure message data.
- *
+ * @warn Deprecated.
+ * @warn Does not reflect CAN message data. Use \ref get_wheel_brake_pressure instead.
  */
 typedef struct
 {

--- a/api/src/oscc.c
+++ b/api/src/oscc.c
@@ -1092,3 +1092,84 @@ oscc_result_t get_device_name( char * string, char * const name )
 
     return result;
 }
+
+oscc_result_t get_wheel_speed_right_rear(
+    struct can_frame const * const frame,
+    double * wheel_speed_right_rear)
+{
+    if((frame == NULL) || (wheel_speed_right_rear == NULL)) { return OSCC_ERROR; }
+    if(frame->can_id != KIA_SOUL_OBD_WHEEL_SPEED_CAN_ID) { return OSCC_ERROR; }
+    uint16_t raw = ((frame->data[7] & 0x0F) << 8) | frame->data[6];
+    // 10^-1 precision, raw / 32.0
+    *wheel_speed_right_rear = (double)((int)((double)raw / 3.2) / 10.0);
+    return OSCC_OK;
+}
+
+
+oscc_result_t get_wheel_speed_left_rear(
+    struct can_frame const * const frame,
+    double * wheel_speed_left_rear)
+{
+    if((frame == NULL) || (wheel_speed_left_rear == NULL)) { return OSCC_ERROR; }
+    if(frame->can_id != KIA_SOUL_OBD_WHEEL_SPEED_CAN_ID) { return OSCC_ERROR; }
+    uint16_t raw = ((frame->data[5] & 0x0F) << 8) | frame->data[4];
+    // 10^-1 precision, raw / 32.0
+    *wheel_speed_left_rear = (double)((int)((double)raw / 3.2) / 10.0);
+    return OSCC_OK;
+}
+
+
+oscc_result_t get_wheel_speed_right_front(
+    struct can_frame const * const frame,
+    double * wheel_speed_right_front)
+{
+    if((frame == NULL) || (wheel_speed_right_front == NULL)) { return OSCC_ERROR; }
+    if(frame->can_id != KIA_SOUL_OBD_WHEEL_SPEED_CAN_ID) { return OSCC_ERROR; }
+    uint16_t raw = ((frame->data[3] & 0x0F) << 8) | frame->data[2];
+    // 10^-1 precision, raw / 32.0
+    *wheel_speed_right_front = (double)((int)((double)raw / 3.2) / 10.0);
+    return OSCC_OK;
+}
+
+
+oscc_result_t get_wheel_speed_left_front(
+    struct can_frame const * const frame,
+    double * wheel_speed_left_front)
+{
+    if((frame == NULL) || (wheel_speed_left_front == NULL)) { return OSCC_ERROR; }
+    if(frame->can_id != KIA_SOUL_OBD_WHEEL_SPEED_CAN_ID) { return OSCC_ERROR; }
+    uint16_t raw = ((frame->data[1] & 0x0F) << 8) | frame->data[0];
+    // 10^-1 precision, raw / 32.0
+    *wheel_speed_left_front = (double)((int)((double)raw / 3.2) / 10.0);
+    return OSCC_OK;
+}
+
+
+oscc_result_t get_steering_wheel_angle(
+    struct can_frame const * const frame,
+    double * steering_wheel_angle)
+{
+    if((frame == NULL) || (steering_wheel_angle == NULL)) { return OSCC_ERROR; }
+    if(frame->can_id != KIA_SOUL_OBD_STEERING_WHEEL_ANGLE_CAN_ID) { return OSCC_ERROR; }
+    int16_t raw = (frame->data[1] << 8) | frame->data[0];
+    *steering_wheel_angle = -((double)raw / 10.0);
+    return OSCC_OK;
+}
+
+
+oscc_result_t get_brake_pressure(
+    struct can_frame const * const frame,
+    double * brake_pressure)
+{
+    if((frame == NULL) || (brake_pressure == NULL)) { return OSCC_ERROR; }
+    if(frame->can_id != KIA_SOUL_OBD_BRAKE_PRESSURE_CAN_ID) { return OSCC_ERROR; }
+#ifdef KIA_NIRO
+    double scale = 40.0;
+    uint16_t raw = ((frame->data[4] & 0x0F) << 8) | frame->data[3];
+#else
+    double scale = 10.0;
+    uint16_t raw = ((frame->data[5] & 0x0F) << 8) | frame->data[4];
+#endif
+    *brake_pressure = (double)raw / scale;
+    return OSCC_OK;
+}


### PR DESCRIPTION
Prior to this commit the expected method for getting relevant data
from the DriveKit OBD-II messages was to cast the CAN frame data as
a C struct. The C structs defined by the API did not reflect the
CAN data in most cases which has the potential to mislead users
and developers who want to use the unpacked CAN data.

This commit represents the addition of "getter" functions
that take as a parameter, the CAN frame read and the value to set.
Each functoin unpacks its respective value from the CAN frame reported
by the vehicle and scales it according to it's unit of measurement (degrees, bar, kph).

Additionally, comments indicating that the old C structs are deprecated were added to the
documentation as removing them completely would represent a breaking change.

Partially addresses #233