### PR TITLE
Add vehicle + OSCC consensus checking tool

### DIFF
--- a/utils/consensus/.gitignore
+++ b/utils/consensus/.gitignore
@@ -1,0 +1,101 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# dotenv
+.env
+
+# virtualenv
+.venv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/

--- a/utils/consensus/README.md
+++ b/utils/consensus/README.md
@@ -3,8 +3,8 @@
 The purpose of this Python 3 program is to provide basic validation that there is the vehicle and
 OSCC can reach a consensus. Ideally it's a method to quickly verify whether your vehicle is in a
 good state. By sending control commands on the CAN gateway then polling for an expected result
-there, we should be able to tell whether OSCC is functioning properly or diagnose
-any issues more readily.
+there, we should be able to tell whether OSCC is functioning properly or diagnose any issues more
+readily.
 
 While this program was designed to be run as a stand alone executable it may be imported as a module
 should a use-case arise.
@@ -44,4 +44,4 @@ sudo ip link set can0 type can bitrate 125000
 sudo ip link set up can0
 ```
 
-Run `diagnostics.py --help` for more info.
+Run `consensus.py --help` for more info.

--- a/utils/consensus/README.md
+++ b/utils/consensus/README.md
@@ -32,7 +32,6 @@ But what does it do?
 
 - `python3` (`sudo apt install python3`)
 - `pip3` (`sudo apt install python3-pip`)
-- `python-can` (`pip3 install python-can`)
 - `colorama` (`pip3 install colorama`)
 - `docopt` (`pip3 install docopt`)
 - `python-can` (`pip3 install python-can`)

--- a/utils/consensus/README.md
+++ b/utils/consensus/README.md
@@ -36,6 +36,10 @@ But what does it do?
 - `docopt` (`pip3 install docopt`)
 - `python-can` (`pip3 install python-can`)
 
+## Compatibility
+
+Works with OSCC `v1.2.1` and up.
+
 ## Usage
 
 Connect your computer to OSCC's CAN bus and bring up your socketcan interface

--- a/utils/consensus/README.md
+++ b/utils/consensus/README.md
@@ -33,7 +33,7 @@ But what does it do?
 - `python3` (`sudo apt install python3`)
 - `pip3` (`sudo apt install python3-pip`)
 - `python-can` (`pip3 install python-can`)
-- `colorama` (`pip3 install python-can`)
+- `colorama` (`pip3 install colorama`)
 - `docopt` (`pip3 install docopt`)
 - `python-can` (`pip3 install python-can`)
 

--- a/utils/consensus/README.md
+++ b/utils/consensus/README.md
@@ -1,0 +1,47 @@
+# Consensus
+
+The purpose of this Python 3 program is to provide basic validation that there is the vehicle and
+OSCC can reach a consensus. Ideally it's a method to quickly verify whether your vehicle is in a
+good state. By sending control commands on the CAN gateway then polling for an expected result
+there, we should be able to tell whether OSCC is functioning properly or diagnose
+any issues more readily.
+
+While this program was designed to be run as a stand alone executable it may be imported as a module
+should a use-case arise.
+
+Prerequisites for success:
+
+- A vehicle with OSCC installed
+- That vehicle powered on (motor on)
+- OSCC powered
+- A socketcan connection to OSCC's CAN bus from your computer
+
+But what does it do?
+
+1. Enable each OSCC module (brake, steering, throttle).
+1. Send commands to increase and decrease brake pressure.
+1. Verify that brake pressure reported by vehicle increased or decreased accordingly.
+1. Send commands to apply positive or negative torque to steering wheel.
+1. Verify that the steering wheel angle increased or decreased accordingly.
+1. Send commands to increase or decrease throttle pressure.
+1. Verify just that the wheel position is reported. (This one's unique in that we don't require the
+   wheel positions to expect as a success condition. They shouldn't if the car's in park!.
+1. Disable each OSCC module.
+
+## Dependencies
+
+- `python3`
+- `pip`
+- `python-can` (run `pip install python-can`)
+- `docopt` (run `pip install docopt`)
+
+## Usage
+
+Connect your computer to OSCC's CAN bus and bring up your socketcan interface
+
+```bash
+sudo ip link set can0 type can bitrate 125000
+sudo ip link set up can0
+```
+
+Run `diagnostics.py --help` for more info.

--- a/utils/consensus/README.md
+++ b/utils/consensus/README.md
@@ -30,10 +30,12 @@ But what does it do?
 
 ## Dependencies
 
-- `python3`
-- `pip`
-- `python-can` (run `pip install python-can`)
-- `docopt` (run `pip install docopt`)
+- `python3` (`sudo apt install python3`)
+- `pip3` (`sudo apt install python3-pip`)
+- `python-can` (`pip3 install python-can`)
+- `colorama` (`pip3 install python-can`)
+- `docopt` (`pip3 install docopt`)
+- `python-can` (`pip3 install python-can`)
 
 ## Usage
 

--- a/utils/consensus/README.md
+++ b/utils/consensus/README.md
@@ -40,7 +40,7 @@ But what does it do?
 Connect your computer to OSCC's CAN bus and bring up your socketcan interface
 
 ```bash
-sudo ip link set can0 type can bitrate 125000
+sudo ip link set can0 type can bitrate 500000
 sudo ip link set up can0
 ```
 

--- a/utils/consensus/README.md
+++ b/utils/consensus/README.md
@@ -1,6 +1,6 @@
 # Consensus
 
-The purpose of this Python 3 program is to provide basic validation that there is the vehicle and
+The purpose of this Python 3 program is to provide basic validation that the vehicle and
 OSCC can reach a consensus. Ideally it's a method to quickly verify whether your vehicle is in a
 good state. By sending control commands on the CAN gateway then polling for an expected result
 there, we should be able to tell whether OSCC is functioning properly or diagnose any issues more

--- a/utils/consensus/consensus.py
+++ b/utils/consensus/consensus.py
@@ -143,6 +143,8 @@ class DebugModules(object):
         # frame to OSCC/DriveKit over its CAN gateway.
         self.bus.disable_module(module)
 
+        time.sleep(1)
+
         # Verify the module parameter is disabled by listening to the OSCC/DriveKit CAN gateway for
         # a status message that confirms it. Set the `success` flag so we can report and handle
         # failure
@@ -160,8 +162,6 @@ class DebugModules(object):
                 module.module_name,
                 'module could not be disabled')
             return False
-
-        time.sleep(1)
 
     def command_brake_module(self, cmd_value, expect=None):
         """

--- a/utils/consensus/consensus.py
+++ b/utils/consensus/consensus.py
@@ -139,11 +139,11 @@ class DebugModules(object):
             module.module_name,
             'module')
 
-        # Attempt to enable the module parameter. Under the hood, this sends the enable brakes CAN
+        # Attempt to disable the module parameter. Under the hood, this sends the disable brakes CAN
         # frame to OSCC/DriveKit over its CAN gateway.
-        self.bus.enable_module(module)
+        self.bus.disable_module(module)
 
-        # Verify the module parameter is enabled by listening to the OSCC/DriveKit CAN gateway for
+        # Verify the module parameter is disabled by listening to the OSCC/DriveKit CAN gateway for
         # a status message that confirms it. Set the `success` flag so we can report and handle
         # failure
         success = self.bus.check_module_enabled_status(
@@ -160,6 +160,8 @@ class DebugModules(object):
                 module.module_name,
                 'module could not be disabled')
             return False
+
+        time.sleep(1)
 
     def command_brake_module(self, cmd_value, expect=None):
         """

--- a/utils/consensus/consensus.py
+++ b/utils/consensus/consensus.py
@@ -405,10 +405,10 @@ def main(args):
         torque_cmd = 0.1
         modules.command_steering_module(torque_cmd, expect=None)
 
-        torque_cmd = 0.2
+        torque_cmd = 0.15
         modules.command_steering_module(torque_cmd, expect='increase')
 
-        torque_cmd = -0.2
+        torque_cmd = -0.15
         modules.command_steering_module(torque_cmd, expect='decrease')
 
         # Visually distinguish steering validation from the following throttle validation

--- a/utils/consensus/consensus.py
+++ b/utils/consensus/consensus.py
@@ -1,0 +1,440 @@
+#!/usr/bin/python3
+"""Usage: consensus.py [-hdel] [-c <channel>] [-v <vehicle>]
+
+Options:
+    -h --help                            Display this information
+    -d --disable                         Disable modules only, no consensus checks (overrides enable)
+    -e --enable                          Enable modules only, no consensus checks
+    -l --loop                            Repeat consensus checks, run continuously
+    -c <channel>, --channel <channel>    Specify CAN channel, defaults to 'can0'
+    -v <vehicle>, --vehicle <vehcile>    Specify your vehcile, defaults to 'kia_soul_ev'
+                                         (kia_soul_ev / kia_soul_petrol / kia_niro)
+"""
+
+# This module lets us sleep intermittently. We're not in a hurry and want to see how the car behaves
+# when commands are spaced out a bit.
+import time
+
+# This module makes it easier to print colored text to stdout
+# `Fore`` is used to set the color and `Style`` is used to reset to default.
+import colorama
+from colorama import Fore, Style
+
+# This is a requirement for this tool's command line argument handling.
+from docopt import docopt
+
+# These are the local modules you would import if you wanted to use this tool as a library rather
+# than an executable.
+from oscccan.canbus import CanBus
+from oscccan.canbus import Report
+from oscccan import OsccModule
+
+class DebugModules(object):
+    """
+    The 'DebugModules' class contains references to each of the OsccModules,
+    brake, steering, and throttle. It is used to manage a majority of the stdout reporting this
+    tool relies on.
+    """
+    def __init__(self, bus, brake, steering, throttle):
+        """
+        Initialize references to modules and CAN bus as well as the 'last_measurement' variable
+        that allows this class to track whether expected increases and decreases occurred.
+        """
+        self.bus = bus
+        self.brake = brake
+        self.steering = steering
+        self.throttle = throttle
+        self.last_measurement = None
+
+    def reading_sleep(self, duration=1.0):
+        end = time.time() + duration
+
+        while time.time() < end:
+            self.bus.recv_report()
+
+    def enable(self):
+        """
+        Enable all OSCC modules.
+        """
+
+        while True:
+
+            success = self.enable_module(self.brake)
+
+            if not success:
+                continue
+
+            success = self.enable_module(self.steering)
+
+            if not success:
+                continue
+
+            success = self.enable_module(self.throttle)
+
+            if not success:
+                continue
+
+            break
+
+    def disable(self):
+        """
+        Disable all OSCC modules.
+        """
+        self.disable_module(self.brake)
+        self.disable_module(self.steering)
+        self.disable_module(self.throttle)
+
+    def enable_module(self, module):
+        """
+        Enable a single OSCC modules. Print status, success and failure reports.
+        """
+
+        print(
+            Fore.MAGENTA + ' status: ',
+            Style.RESET_ALL,
+            'attempting to enable',
+            module.module_name,
+            'module')
+
+        # Attempt to enable the module parameter. Under the hood, this sends the enable brakes CAN
+        # frame to OSCC/DriveKit over its CAN gateway.
+        self.bus.enable_module(module)
+
+        # Verify the module parameter is enabled by listening to the OSCC/DriveKit CAN gateway for
+        # a status message that confirms it. Set the `success` flag so we can report and handle
+        # failure
+        success = self.bus.check_module_enabled_status(
+            module,
+            expect=True)
+
+        if success:
+            print(Fore.GREEN + ' success:', Style.RESET_ALL, module.module_name, 'module enabled')
+        else:
+            print(
+                Fore.RED +
+                ' error:  ',
+                Style.RESET_ALL,
+                module.module_name,
+                'module could not be enabled')
+
+        self.reading_sleep()
+
+        return success
+
+    def disable_module(self, module):
+        """
+        Disable a single OSCC modules. Print status, success and failure reports.
+        """
+
+        print(
+            Fore.MAGENTA + ' status: ',
+            Style.RESET_ALL,
+            'attempting to disable',
+            module.module_name,
+            'module')
+
+        # Attempt to enable the module parameter. Under the hood, this sends the enable brakes CAN
+        # frame to OSCC/DriveKit over its CAN gateway.
+        self.bus.enable_module(module)
+
+        # Verify the module parameter is enabled by listening to the OSCC/DriveKit CAN gateway for
+        # a status message that confirms it. Set the `success` flag so we can report and handle
+        # failure
+        success = self.bus.check_module_enabled_status(
+            module,
+            expect=False)
+
+        if success:
+            print(Fore.GREEN + ' success:', Style.RESET_ALL, module.module_name, 'module disabled')
+            return True
+        else:
+            print(
+                Fore.RED + ' error:  ',
+                Style.RESET_ALL,
+                module.module_name,
+                'module could not be disabled')
+            return False
+
+    def command_brake_module(self, cmd_value, expect=None):
+        """
+        Command OSCC brake module and verify resulting behavior. Print status, success and
+        failure reports.
+        """
+
+        if expect is not None:
+            print(
+                Fore.MAGENTA + ' status: ',
+                Style.RESET_ALL,
+                'attempting to',
+                expect,
+                'brake pressure from',
+                self.last_measurement, 'bar')
+
+        print(
+            Fore.MAGENTA + ' status: ',
+            Style.RESET_ALL,
+            'sending command value',
+            cmd_value,
+            'to brake module')
+        self.bus.send_command(self.brake, cmd_value, timeout=1.0)
+
+        print(Fore.MAGENTA + ' status: ', Style.RESET_ALL, 'measuring brake pressure')
+
+        if expect == 'increase':
+            report = self.bus.check_brake_pressure(timeout=1.0, increase_from=self.last_measurement)
+        elif expect == 'decrease':
+            report = self.bus.check_brake_pressure(timeout=1.0, decrease_from=self.last_measurement)
+        else:
+            report = self.bus.check_brake_pressure(timeout=1.0)
+
+        if report.success is True:
+            print(
+                Fore.GREEN + ' success:',
+                Style.RESET_ALL,
+                'brake pressure measured at',
+                report.value,
+                'bar')
+        else:
+            if report.value is not None and expect is not None:
+                print(
+                    Fore.YELLOW + ' unexpected:',
+                    Style.RESET_ALL,
+                    'brake pressure measured at',
+                    report.value,
+                    '(did not measure',
+                    expect,
+                    'from last measurement',
+                    self.last_measurement,
+                    ')')
+            else:
+                print(Fore.RED + ' error:  ', Style.RESET_ALL, 'failed to read brake pressure')
+
+        self.last_measurement = report.value
+
+
+        self.reading_sleep()
+
+    def command_steering_module(self, cmd_value, expect=None):
+        """
+        Command OSCC steering module and verify resulting behavior. Print status, success and
+        failure reports.
+        """
+
+        if expect is not None:
+            direction = 'positive' if expect == 'increase' else 'negative'
+            print(
+                Fore.MAGENTA + ' status: ',
+                Style.RESET_ALL,
+                direction,
+                'torque applied to steering wheel')
+
+        print(
+            Fore.MAGENTA + ' status: ',
+            Style.RESET_ALL,
+            'sending command value',
+            cmd_value,
+            'to steering module')
+        self.bus.send_command(self.steering, cmd_value, timeout=1.0)
+
+        self.reading_sleep(1)
+
+        print(Fore.MAGENTA + ' status: ', Style.RESET_ALL, 'measuring steering wheel angle')
+
+        report = Report()
+        report.success = False
+        if expect == 'increase':
+            report = self.bus.check_steering_wheel_angle(
+                timeout=1.0,
+                increase_from=self.last_measurement)
+        elif expect == 'decrease':
+            report = self.bus.check_steering_wheel_angle(
+                timeout=1.0,
+                decrease_from=self.last_measurement)
+        else:
+            report = self.bus.check_steering_wheel_angle(timeout=1.0)
+
+        if report.success is True:
+            print(
+                Fore.GREEN + ' success:',
+                Style.RESET_ALL,
+                'steering wheel angle measured at',
+                str(report.value) + '°')
+        else:
+            if report.value is not None and expect is not None:
+                print(
+                    Fore.YELLOW + ' unexpected:',
+                    Style.RESET_ALL,
+                    'steering wheel angle measured at',
+                    report.value,
+                    '(did not measure', expect,
+                    'from last measurement',
+                    str(self.last_measurement) + '°)')
+            else:
+                print(
+                    Fore.RED + ' error:  ',
+                    Style.RESET_ALL,
+                    'failed to read steering wheel angle')
+
+        self.last_measurement = report.value
+
+        self.reading_sleep()
+
+    def command_throttle_module(self, cmd_value, expect=None):
+        """
+        Command OSCC throttle module and verify resulting behavior. Print status, success and
+        failure reports.
+        """
+
+        if expect is not None:
+            print(
+                Fore.RED + ' unexpected:',
+                Style.RESET_ALL,
+                'no logic to measure',
+                expect,
+                'in wheel speed')
+
+        print(
+            Fore.MAGENTA + ' status: ',
+            Style.RESET_ALL,
+            'sending command value',
+            cmd_value,
+            'to throttle module')
+
+        self.bus.send_command(self.throttle, cmd_value, timeout=1.0)
+
+        print(Fore.MAGENTA + ' status:', Style.RESET_ALL, ' measuring wheel speed')
+
+        report = self.bus.check_wheel_speed(timeout=1.0)
+
+        if report.success is True and report.value is not None:
+            print(
+                Fore.GREEN + ' success:', Style.RESET_ALL,
+                'wheel speeds measured at lf', str(report.value[0]) +
+                ', rf', str(report.value[1]) +
+                ', lr', str(report.value[2]) +
+                ', rr', str(report.value[3]))
+        else:
+            print(Fore.RED + ' error:', Style.RESET_ALL, '  failed to read wheel speeds')
+
+        self.last_measurement = report.value
+
+        self.reading_sleep()
+
+def check_vehicle_arg(arg):
+    """
+    Sanity check the optional vehicle argument.
+    """
+
+    vehicles = ['kia_soul_ev', 'kia_soul_petrol', 'kia_niro', None]
+    if arg not in vehicles:
+        raise ValueError('Unable to target vehicle', arg + '. Options are', vehicles)
+
+def main(args):
+    check_vehicle_arg(args['--vehicle'])
+
+    channel = 'can0' if args['--channel'] is None else str(args['--channel'])
+
+    bus = CanBus(channel=channel, vehicle=args['--vehicle'])
+
+    brakes = OsccModule(base_arbitration_id=0x70, module_name='brake')
+    steering = OsccModule(base_arbitration_id=0x80, module_name='steering')
+    throttle = OsccModule(base_arbitration_id=0x90, module_name='throttle')
+
+    modules = DebugModules(bus, brakes, steering, throttle)
+
+    # Initialize module for printing colored text to stdout
+    colorama.init()
+
+    if args['--disable']:
+        modules.disable()
+        return
+    elif args['--enable']:
+        modules.enable()
+        return
+
+    # Each section or step of the following loop is distinguished from the next by this separator.
+    # The output begins with this separator for visually consistent output.
+    print("|Enable Modules -----------------------------------------------------------------|")
+
+    # This `while` loop repeats the same basic steps on each iteration, they are as follows:
+    # 1. Enable each OSCC module.
+    # 2. Send commands to increase and decrease brake pressure.
+    # 3. Verify that brake pressure reported by vehicle increased or decreased accordingly.
+    # 4. Send commands to apply positive or negative torque to steering wheel.
+    # 5. Verify that the steering wheel angle increased or decreased accordingly.
+    # 6. Send commands to increase or decrease throttle application.
+    # 7. Verify that the wheel position is reported. (This one's unique in that we don't require the
+    # wheel positions to expect as a success condition. They shouldn't if the car's in park!.
+    # 8. Disable each OSCC module.
+    while True:
+
+        modules.enable()
+
+        # Visually distinguish enable steps from the following brake validation
+        print("|Brake Test --------------------------------------------------------------------|")
+
+        pressure_cmd = 0.0
+        modules.command_brake_module(pressure_cmd, expect=None)
+
+        pressure_cmd = 0.5
+        modules.command_brake_module(pressure_cmd, expect='increase')
+
+        pressure_cmd = 0.0
+        modules.command_brake_module(pressure_cmd, expect='decrease')
+
+        pressure_cmd = 0.3
+        modules.command_brake_module(pressure_cmd, expect='increase')
+
+        pressure_cmd = 0.0
+        modules.command_brake_module(pressure_cmd, expect='decrease')
+
+        # Visually distinguish brake validation from the following steering wheel validation
+        print("|Steering Test ------------------------------------------------------------------|")
+
+        torque_cmd = -0.1
+        modules.command_steering_module(torque_cmd, expect=None)
+
+        torque_cmd = 0.1
+        modules.command_steering_module(torque_cmd, expect=None)
+
+        torque_cmd = 0.2
+        modules.command_steering_module(torque_cmd, expect='increase')
+
+        torque_cmd = -0.2
+        modules.command_steering_module(torque_cmd, expect='decrease')
+
+        # Visually distinguish steering validation from the following throttle validation
+        print("|Throttle Test ------------------------------------------------------------------|")
+
+        pressure_cmd = 0.0
+        modules.command_throttle_module(pressure_cmd, expect=None)
+
+        pressure_cmd = 0.05
+        modules.command_throttle_module(pressure_cmd, expect=None)
+
+        pressure_cmd = 0.1
+        modules.command_throttle_module(pressure_cmd, expect=None)
+
+        pressure_cmd = 0.05
+        modules.command_throttle_module(pressure_cmd, expect=None)
+
+        pressure_cmd = 0.0
+        modules.command_throttle_module(pressure_cmd, expect=None)
+
+        # Visually distinguish throttle validation from the following disable steps
+        print("|Disable Modules ----------------------------------------------------------------|")
+
+        modules.disable()
+
+        if not args['--loop']:
+            break
+
+        # Visually distinguish disable steps from the following enable steps
+        print("|Enable Modules -----------------------------------------------------------------|")
+
+if __name__ == "__main__":
+    """
+    The program's entry point if run as an executable.
+    """
+
+    main(docopt(__doc__))

--- a/utils/consensus/consensus.py
+++ b/utils/consensus/consensus.py
@@ -47,6 +47,12 @@ class DebugModules(object):
         self.last_measurement = None
 
     def reading_sleep(self, duration=1.0):
+        """
+        Used in place of `time.sleep()`. Enables "waiting" for some interval while maintaining
+        confidence that once we start unpacking at the car's reports again that data hasn't gone
+        stale.
+        """
+
         end = time.time() + duration
 
         while time.time() < end:

--- a/utils/consensus/oscccan/__init__.py
+++ b/utils/consensus/oscccan/__init__.py
@@ -1,0 +1,30 @@
+"""
+Import as 'oscccan'
+"""
+
+__all__ = [
+    'canbus',
+    ]
+
+class OsccModule(object):
+    """
+    Wrapper to CAN data specific to an OSCC module. Used with CanBus class to
+    communicate on the OSCC CAN bus.
+    """
+    def __init__(self, base_arbitration_id, module_name=None):
+        """
+        Initialize CAN data specific to OSCC module.
+        """
+        try:
+            int(base_arbitration_id)
+        except:
+            raise ValueError(
+                'unable to represent given base_arbitration_id as an integer: ',
+                base_arbitration_id)
+
+        self.magic_word = [0x05, 0xCC]
+        self.enable_arbitration_id = base_arbitration_id
+        self.disable_arbitration_id = base_arbitration_id + 1
+        self.command_arbitration_id = base_arbitration_id + 2
+        self.report_arbitration_id = base_arbitration_id + 3
+        self.module_name = module_name

--- a/utils/consensus/oscccan/canbus.py
+++ b/utils/consensus/oscccan/canbus.py
@@ -1,5 +1,5 @@
 """
-Import as 'canbus' from 'oscc'. Contains 'CanBus' class used for communicating on the OSCC CAN bus
+Import as 'canbus' from 'oscccan'. Contains 'CanBus' class used for communicating on the OSCC CAN bus
 as well as the 'Report' class that the CanBus class's command methods return.
 """
 

--- a/utils/consensus/oscccan/canbus.py
+++ b/utils/consensus/oscccan/canbus.py
@@ -1,0 +1,307 @@
+"""
+Import as 'canbus' from 'oscc'. Contains 'CanBus' class used for communicating on the OSCC CAN bus
+as well as the 'Report' class that the CanBus class's command methods return.
+"""
+
+# This is the module required for everything CAN bus. It is not default on most systems though
+# and needs to be installed with something like `pip install python-can`
+import can
+# The `struct` module is really helpful for packing bytes into messages for transmission on the CAN
+# bus as well as unpacking bytes into an object for this program's consumption.
+import struct
+# This module lets us sleep intermittently. We're not in a hurry and want to see how the car behaves
+# when commands are spaced out a bit.
+import time
+
+from oscccan import OsccModule
+
+class Report(object):
+    """
+    Class returned by the command methods of the 'CanBus' class.
+    """
+    def __init__(self, success=None, value=None):
+        self.success = success
+        self.value = value
+
+class CanBus(object):
+    """
+    CanBus class for to connecting to a CAN bus and communicating with OSCC modules.
+    """
+    def __init__(
+        self,
+        bustype='socketcan_native',
+        channel='can0',
+        bitrate=500000,
+        vehicle='kia_soul_ev'):
+        """
+        Connect to CAN bus.
+        """
+
+        try:
+            self.bus = can.interface.Bus(
+                bustype=bustype,
+                channel=channel,
+                bitrate=bitrate)
+        except:
+            raise Exception(
+                'unable to connect to CAN bus, check that hardware '
+                'is connected and that socketcan is active')
+
+        self.brake_pressure_arbitration_ids = [0x220]
+        self.steering_wheel_angle_arbitration_ids = [0x2B0]
+        self.wheel_speed_arbitration_ids = [0x4B0, 0x386]
+        self.vehicle = vehicle
+
+    def bus_send_msg(self, arbitration_id, data=None, timeout=1.0):
+        """
+        Send a frame on OSCC CAN bus.
+        """
+
+        msg = can.Message(
+            arbitration_id=arbitration_id,
+            data=data)
+        self.bus.send(msg, timeout=timeout)
+
+    def enable_module(self, module, timeout=None):
+        """
+        Send enable command specific to the module parameter.
+        """
+        if not isinstance(module, OsccModule):
+            raise TypeError('cannot enable', module)
+
+        self.bus_send_msg(
+            arbitration_id=module.enable_arbitration_id,
+            data=module.magic_word + [0, 0, 0, 0, 0, 0],
+            timeout=timeout
+        )
+
+    def disable_module(self, module, timeout=None):
+        """
+        Send disable command specific to the module parameter.
+        """
+        if not isinstance(module, OsccModule):
+            raise TypeError('cannot disable', module)
+
+        self.bus_send_msg(
+            arbitration_id=module.disable_arbitration_id,
+            data=module.magic_word + [0, 0, 0, 0, 0, 0],
+            timeout=timeout
+        )
+
+    def check_module_enabled_status(
+        self,
+        module,
+        timeout=1.0,
+        expect=False):
+        """
+        Check if OSCC module is enabled/disabled.
+        """
+        if not isinstance(module, OsccModule):
+            raise TypeError('cannot check status for', module)
+
+        status = False
+        wait = time.time() + timeout
+
+        while True:
+            if time.time() > wait:
+                break
+
+            msg = self.recv_report(module=module, timeout=timeout)
+
+            if msg is not None:
+                byte_lst = list(msg.data)
+                if byte_lst[2] != 0 and expect is True:
+                    status = True
+                    break
+
+                if byte_lst[2] == 0 and expect is False:
+                    status =  False
+                    break
+
+                if byte_lst[2] != 0:
+                    status = True
+                else:
+                    status = False
+
+        return status
+
+    def send_command(
+        self,
+        module,
+        value,
+        timeout=None):
+        """
+        Send control command specifed by floating point value to the OsccModule parameter.
+        """
+        if not isinstance(module, OsccModule):
+            raise TypeError('cannot send command to', module)
+
+        try:
+            float(value)
+        except:
+            raise ValueError('invalid command', value)
+
+        byte_list = list(bytearray(struct.pack("f", value)))
+
+        self.bus_send_msg(
+            arbitration_id=module.command_arbitration_id,
+            data=module.magic_word + byte_list + [0, 0],
+            timeout=timeout
+        )
+
+    def recv_report(
+        self,
+        module=None,
+        can_ids=None,
+        timeout=1.0):
+        """
+        If OsccModule parameter is valid, return its report message.
+        If OsccModule invalid and can_id is valid, return message with that ID.
+        If both OsccModule and can_id are invalid, return first message received.
+        """
+        msg_ids = []
+        if can_ids is not None:
+            if not isinstance(can_ids, list):
+                msg_ids.append(can_ids)
+            else:
+                msg_ids.extend(can_ids)
+
+        # throw away can_id if module parameter is valid
+        if module is not None:
+            if not isinstance(module, OsccModule):
+                raise TypeError('cannot find CAN ID in', module)
+            msg_ids.append(module.report_arbitration_id)
+
+        wait = time.time() + timeout
+
+        while True:
+            msg = self.bus.recv(timeout)
+            if msg is not None:
+                if msg.arbitration_id in msg_ids:
+                    return msg
+                elif can_ids is None and module is None:
+                    return msg
+            else:
+                return None
+
+            if wait > time.time():
+                return None
+
+    def check_brake_pressure(
+        self,
+        increase_from=None,
+        decrease_from=None,
+        timeout=2.0,):
+        """
+        Check brake pressure report from vehicle. If the increase_from or decrease_from parameters
+        are populated, verify the reported value did increase or decrease.
+        """
+        value = None
+        wait = time.time() + timeout
+
+        while True:
+            if time.time() > wait:
+                if increase_from is None and decrease_from is None:
+                    value = None
+                return Report(success=False, value=value)
+
+            msg = self.recv_report(can_ids=self.brake_pressure_arbitration_ids, timeout=timeout)
+
+            if msg is None:
+                continue
+
+            if self.vehicle == 'kia_niro':
+                # Niro
+                byte1 = (msg.data[4] & 0x0F) << 8
+                byte0 = msg.data[3]
+                value = int(str(byte1|byte0), 10)
+                value /= 40
+            else:
+                # Soul EV and Petrol
+                byte1 = (msg.data[5] & 0x0F) << 8
+                byte0 = msg.data[4]
+                value = int(str(byte1|byte0), 10)
+                value /= 10
+
+            if increase_from is not None:
+                if value > increase_from:
+                    return Report(success=True, value=value)
+            elif decrease_from is not None:
+                if value < decrease_from:
+                    return Report(success=True, value=value)
+            else:
+                return Report(success=True, value=value)
+
+    def check_steering_wheel_angle(
+        self,
+        increase_from=None,
+        decrease_from=None,
+        timeout=2.0):
+        """
+        Check steering wheel angle report from vehicle. If the increase_from or decrease_from
+        parameters are populated, verify the reported value did increase or decrease.
+        """
+        value = None
+        wait = time.time() + timeout
+
+        while True:
+            if time.time() > wait:
+                if increase_from is None and decrease_from is None:
+                    value = None
+                return Report(success=False, value=value)
+
+            msg = self.recv_report(
+                can_ids=self.steering_wheel_angle_arbitration_ids,
+                timeout=timeout)
+
+            if msg is None:
+                continue
+
+            value = -float(struct.unpack("h", msg.data[:2])[0]) / 10.0
+
+            if increase_from is not None:
+                if value > increase_from:
+                    return Report(success=True, value=value)
+            elif decrease_from is not None:
+                if value < decrease_from:
+                    return Report(success=True, value=value)
+            else:
+                return Report(success=True, value=value)
+
+    def get_wheel_speed(self, data, offset):
+        """
+        Wheel speed unpacking logic generic across offsets.
+        """
+        byte1 = (data[offset + 1] & 0x0F) << 8
+        byte0 = data[offset]
+        value = int(str(byte1|byte0), 10)
+
+        return float(value) / 10.0
+
+    def check_wheel_speed(
+        self,
+        timeout=2.0):
+        """
+        Check wheel speed report from vehicle.
+        """
+
+        wait = time.time() + timeout
+
+        while True:
+            if time.time() > wait:
+                return Report(success=False, value=None)
+
+            msg = self.recv_report(can_ids=self.wheel_speed_arbitration_ids, timeout=timeout)
+
+            if msg is not None:
+                left_front = None
+                right_front = None
+                left_rear = None
+                right_rear = None
+
+                left_front = self.get_wheel_speed(msg.data, 0)
+                right_front = self.get_wheel_speed(msg.data, 2)
+                left_rear = self.get_wheel_speed(msg.data, 4)
+                right_rear = self.get_wheel_speed(msg.data, 6)
+
+                return Report(success=True, value=[left_front, right_front, left_rear, right_rear])

--- a/utils/consensus/oscccan/canbus.py
+++ b/utils/consensus/oscccan/canbus.py
@@ -115,13 +115,8 @@ class CanBus(object):
                     break
 
                 if byte_lst[2] == 0 and expect is False:
-                    status =  False
+                    status =  True
                     break
-
-                if byte_lst[2] != 0:
-                    status = True
-                else:
-                    status = False
 
         return status
 


### PR DESCRIPTION
Prior to this commit there was no easy way to verify that OSCC
and the vehicle were on the same page after an install. Usually
validation after install required the joystick commander application
but that provides no indication as to whether the vehicle reports
what we expect it to after sending commands.

After this commit the OSCC repo will have the `consensus.py` program
to verify that OSCC and the vehicle are on the same page or report
otherwise. Ideally this program will be the first step taken after
installing OSCC. It will also help pinpoint issues if the vehicle
provides unexpected or error results if OSCC expected different
information.