### PR TITLE
Update the CMake include path

### DIFF
--- a/api/OsccConfig.cmake
+++ b/api/OsccConfig.cmake
@@ -1,1 +1,1 @@
-include(${CMAKE_SOURCE_DIR}/../firmware/cmake/OsccConfig.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/../firmware/cmake/OsccConfig.cmake)


### PR DESCRIPTION
This pull request changes the variable for the API include file so that using oscc as a git submodule can be used.