### PR TITLE
Add arduino init to null implementation

### DIFF
--- a/firmware/null/CMakeLists.txt
+++ b/firmware/null/CMakeLists.txt
@@ -6,4 +6,11 @@ set(ARDUINO_DEFAULT_BAUDRATE ${SERIAL_BAUD_NULL})
 generate_arduino_firmware(
     null
     SRCS
-    main.cpp)
+    main.cpp
+    ${OSCC_FIRMWARE_ROOT}/common/libs/arduino_init/arduino_init.cpp)
+
+target_include_directories(
+    null
+    PRIVATE
+    ${OSCC_FIRMWARE_ROOT}/common/libs/arduino_init
+)

--- a/firmware/null/main.cpp
+++ b/firmware/null/main.cpp
@@ -2,7 +2,12 @@
  * @file main.cpp
  * NULL Implementation
  */
+
+#include "arduino_init.h"
+
 int main( void )
 {
+    init_arduino( );
+
     while( true ) { }
 }


### PR DESCRIPTION
Prior to this commit the null implementation did not initialize the Arduino code
in the firmware. This commit fixes that by adding arduino_init to the null
firmware.