### PR TITLE
Fix test port collision during builds

### DIFF
--- a/firmware/can_gateway/tests/CMakeLists.txt
+++ b/firmware/can_gateway/tests/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(can-gateway-unit-tests)
 
+set(CUCUMBER_PORT_GATEWAY "39${PORT_SUFFIX}")
+
 add_library(
     can-gateway
     SHARED
@@ -45,4 +47,4 @@ add_custom_target(
     DEPENDS
     can-gateway-unit-test
     COMMAND
-    can-gateway-unit-test --port=3902 >/dev/null & cucumber _2.0.0_ ${CMAKE_CURRENT_SOURCE_DIR}/features )
+    can-gateway-unit-test --port=${CUCUMBER_PORT_GATEWAY} >/dev/null & cucumber _2.0.0_ ${CMAKE_CURRENT_SOURCE_DIR}/features )

--- a/firmware/can_gateway/tests/CMakeLists.txt
+++ b/firmware/can_gateway/tests/CMakeLists.txt
@@ -42,6 +42,8 @@ target_include_directories(
     ${CMAKE_SOURCE_DIR}/common/testing/framework/cgreen/include
     ${CMAKE_SOURCE_DIR}/../api/include)
 
+file(WRITE ${CMAKE_CURRENT_LIST_DIR}/features/step_definitions/cucumber.wire "host: localhost\nport: ${CUCUMBER_PORT_GATEWAY}")
+
 add_custom_target(
     run-can-gateway-unit-tests
     DEPENDS

--- a/firmware/can_gateway/tests/features/step_definitions/cucumber.wire
+++ b/firmware/can_gateway/tests/features/step_definitions/cucumber.wire
@@ -1,2 +1,0 @@
-host: localhost
-port: 3902


### PR DESCRIPTION
The can gateway was missed when adding port numbers to cucumber tests causing Jenkins build tests to intermittently fail on port collision. This pull request fixes that by adding dynamic port numbers so that the port is tied to the Jenkins executor rather than a fixed number.