### PR TITLE
Remove dcan filters

### DIFF
--- a/api/include/vehicles/kia_soul_ev.h
+++ b/api/include/vehicles/kia_soul_ev.h
@@ -50,6 +50,12 @@
 #define KIA_SOUL_OBD_BRAKE_PRESSURE_CAN_ID ( 0x220 )
 
 /*
+ * @brief ID of the Kia Soul's OBD throttle pressure CAN frame.
+ *
+ */
+#define KIA_SOUL_OBD_THROTTLE_PRESSURE_CAN_ID ( 0x200 )
+
+/*
  * @brief Factor to scale OBD steering angle to degrees
  *
  */

--- a/api/src/oscc.c
+++ b/api/src/oscc.c
@@ -529,10 +529,7 @@ void oscc_update_status( int sig, siginfo_t *siginfo, void *context )
 
         while( vehicle_can_bytes > 0 )
         {
-            if ( obd_frame_callback != NULL &&
-                 ( rx_frame.can_id == KIA_SOUL_OBD_WHEEL_SPEED_CAN_ID ||
-                   rx_frame.can_id == KIA_SOUL_OBD_BRAKE_PRESSURE_CAN_ID ||
-                   rx_frame.can_id == KIA_SOUL_OBD_STEERING_WHEEL_ANGLE_CAN_ID ) )
+            if ( obd_frame_callback != NULL )
             {
                 obd_frame_callback( &rx_frame );
             }


### PR DESCRIPTION
This PR removes a set of unnecessary filters applied on the diagnotics CAN data that conflict with work done for Apollo on ROSCCO.
This PR also add the Kia Soul EV CAN-ID for the throttle.