### PR TITLE
Add Niro throttle CAN-ID

### DIFF
--- a/api/include/vehicles/kia_niro.h
+++ b/api/include/vehicles/kia_niro.h
@@ -50,6 +50,12 @@
 #define KIA_SOUL_OBD_BRAKE_PRESSURE_CAN_ID ( 0x220 )
 
 /*
+ * @brief ID of the Kia Niro's OBD throttle pressure CAN frame.
+ *
+ */
+#define KIA_SOUL_OBD_THROTTLE_PRESSURE_CAN_ID ( 0x371 )
+
+/*
  * @brief ID of the Kia Niro's OBD speed CAN frame.
  *
  */


### PR DESCRIPTION
This PR adds the Niro throttle pressure CAN-ID to `kia_niro.h`.