### PR TITLE
Increase required steering torque to override

### DIFF
--- a/api/include/vehicles/kia_niro.h
+++ b/api/include/vehicles/kia_niro.h
@@ -366,7 +366,7 @@ typedef struct
  *        override.
  *
  */
-#define TORQUE_DIFFERENCE_OVERRIDE_THRESHOLD ( 1600 )
+#define TORQUE_DIFFERENCE_OVERRIDE_THRESHOLD ( 2000 )
 
 
 

--- a/api/include/vehicles/kia_soul_ev.h
+++ b/api/include/vehicles/kia_soul_ev.h
@@ -345,7 +345,7 @@ typedef struct
  *        override.
  *
  */
-#define TORQUE_DIFFERENCE_OVERRIDE_THRESHOLD ( 1600 )
+#define TORQUE_DIFFERENCE_OVERRIDE_THRESHOLD ( 2000 )
 
 
 

--- a/api/include/vehicles/kia_soul_petrol.h
+++ b/api/include/vehicles/kia_soul_petrol.h
@@ -407,7 +407,7 @@ typedef struct
  *        override.
  *
  */
-#define TORQUE_DIFFERENCE_OVERRIDE_THRESHOLD ( 1600 )
+#define TORQUE_DIFFERENCE_OVERRIDE_THRESHOLD ( 2000 )
 
 
 


### PR DESCRIPTION
Prior to this commit custom applications that required rapid and changes to the steering wheel position were able to programatically apply enough torque to artificially trigger operator override. This resulted in applications where the steering module disabled in unintended ways. This commit addresses that by increasing the torque required to trigger operator override without significantly impeding the a safety driver's ability to trigger override by manually turning the steering wheel. After this commit applications that require rapid changes to steering angle position should not result in any unintended disabling of the steering module.