### PR TITLE
Clean working directory

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,47 +19,57 @@ node {
             node {
                 checkout scm
 
-                image = docker.build("cmake-build:${env.BUILD_ID}")
+                try {
+                    image = docker.build("cmake-build:${env.BUILD_ID}")
 
-                stage("Build ${platform}") {
-                    image.inside {
-                        sh "cd firmware && \
-                            rm -rf build_${platform} && \
-                            mkdir build_${platform} && \
-                            cd build_${platform} && \
-                            cmake -DVEHICLE=${platform} -DCMAKE_BUILD_TYPE=Release .. && \
-                            make"
+                    stage("Build ${platform}") {
+                        image.inside {
+                            sh "cd firmware && \
+                                rm -rf build_${platform} && \
+                                mkdir build_${platform} && \
+                                cd build_${platform} && \
+                                cmake -DVEHICLE=${platform} -DCMAKE_BUILD_TYPE=Release .. && \
+                                make"
 
-                        echo "${platform}: Build Complete!"
+                            echo "${platform}: Build Complete!"
+                        }
+                    }
+
+                    stage("Test ${platform} unit tests") {
+                        image.inside {
+                            sh "cd firmware && \
+                                rm -rf build_${platform}_tests && \
+                                mkdir build_${platform}_tests && \
+                                cd build_${platform}_tests && \
+                                cmake -DVEHICLE=${platform} \
+                                  -DTESTS=ON \
+                                  -DPORT_SUFFIX=${EXECUTOR_NUMBER}${platform_idx} \
+                                  -DCMAKE_BUILD_TYPE=Release \
+                                  .. && \
+                                make run-unit-tests"
+                            echo "${platform}: Unit Tests Complete!"
+                        }
+                    }
+
+                    stage("Test ${platform} property-based tests") {
+                        image.inside("--user root:root") {
+                            sh "cd firmware/build_${platform}_tests && \
+                                make run-property-tests"
+                            echo "${platform}: Property-Based Tests Complete!"
+                        }
                     }
                 }
-
-                stage("Test ${platform} unit tests") {
-                    image.inside {
-                        sh "cd firmware && \
-                            rm -rf build_${platform}_tests && \
-                            mkdir build_${platform}_tests && \
-                            cd build_${platform}_tests && \
-                            cmake -DVEHICLE=${platform} \
-                              -DTESTS=ON \
-                              -DPORT_SUFFIX=${EXECUTOR_NUMBER}${platform_idx} \
-                              -DCMAKE_BUILD_TYPE=Release \
-                              .. && \
-                            make run-unit-tests"
-                        echo "${platform}: Unit Tests Complete!"
-                    }
-                }
-
-                stage("Test ${platform} property-based tests") {
-                    image.inside("--user root:root") {
-                        sh "cd firmware/build_${platform}_tests && \
-                            make run-property-tests"
-                        echo "${platform}: Property-Based Tests Complete!"
-                    }
+                finally {
+                    deleteDir()
                 }
             }
         }
     }
 
-    parallel builds
+    try {
+        parallel builds
+    }
+    finally {
+        deleteDir()
+    }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,9 +17,9 @@ node {
         def platform = platforms[platform_idx]
         builds[platform] = {
             node {
-                checkout scm
-
                 try {
+                    checkout scm
+                    
                     image = docker.build("cmake-build:${env.BUILD_ID}")
 
                     stage("Build ${platform}") {


### PR DESCRIPTION
Prior to this commit failed builds would leave a dirty working directory. This
commit fixes that by adding a try, finally block to make sure the directory is
cleaned.