### PR TITLE
Add EV & Niro vehicle speed can ids

### DIFF
--- a/api/include/vehicles/kia_niro.h
+++ b/api/include/vehicles/kia_niro.h
@@ -59,7 +59,7 @@
  * @brief ID of the Kia Niro's OBD speed CAN frame.
  *
  */
-#define KIA_SOUL_OBD_SPEED_CAN_ID ( 0x371 )
+#define KIA_SOUL_OBD_SPEED_CAN_ID ( 0x52A )
 
 /*
  * @brief Factor to scale OBD steering angle to degrees

--- a/api/include/vehicles/kia_soul_ev.h
+++ b/api/include/vehicles/kia_soul_ev.h
@@ -56,6 +56,12 @@
 #define KIA_SOUL_OBD_THROTTLE_PRESSURE_CAN_ID ( 0x200 )
 
 /*
+ * @brief ID of the Kia Niro's OBD speed CAN frame.
+ *
+ */
+#define KIA_SOUL_OBD_SPEED_CAN_ID ( 0x524 )
+
+/*
  * @brief Factor to scale OBD steering angle to degrees
  *
  */


### PR DESCRIPTION
This PR updates the Kia Niro vehicle speed CAN ID and adds the Kia Soul EV vehicle speed CAN ID.