### PR TITLE
reduce BREAK_PEDAL_OVERRIDE_THRESHOLD

### DIFF
--- a/api/include/vehicles/kia_niro.h
+++ b/api/include/vehicles/kia_niro.h
@@ -239,7 +239,7 @@ typedef struct
     BRAKE_SPOOF_HIGH_SIGNAL_VOLTAGE_MIN  )
 
 /*
- * @brief Value of the accelerator position that indicates operator override. [steps]
+ * @brief Value of the brake position that indicates operator override. [steps]
  *
  */
 #define BRAKE_PEDAL_OVERRIDE_THRESHOLD ( 130 )

--- a/api/include/vehicles/kia_niro.h
+++ b/api/include/vehicles/kia_niro.h
@@ -242,7 +242,7 @@ typedef struct
  * @brief Value of the accelerator position that indicates operator override. [steps]
  *
  */
-#define BRAKE_PEDAL_OVERRIDE_THRESHOLD ( 200 )
+#define BRAKE_PEDAL_OVERRIDE_THRESHOLD ( 130 )
 
 /*
  * @brief Minimum value of the high spoof signal that activates the brake lights. [steps]


### PR DESCRIPTION
BREAK_PEDAL_OVERRIDE_THRESHOLD in https://github.com/PolySync/oscc/blob/master/api/include/vehicles/kia_niro.h was originally =200. It is now reduced to 130 which is the observed level at which the brake lights are triggered. 

Initial testing on vehicle shows this threshold is high enough to not trigger accidental overrides when braking with joystick commander. 

closes issue DriveKit/#117