### PR TITLE
Fix jenkins workspace cleanup

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,50 +17,45 @@ node {
         def platform = platforms[platform_idx]
         builds[platform] = {
             node {
-                try {
-                    checkout scm
-                    
-                    image = docker.build("cmake-build:${env.BUILD_ID}")
+                checkout scm
 
-                    stage("Build ${platform}") {
-                        image.inside {
-                            sh "cd firmware && \
-                                rm -rf build_${platform} && \
-                                mkdir build_${platform} && \
-                                cd build_${platform} && \
-                                cmake -DVEHICLE=${platform} -DCMAKE_BUILD_TYPE=Release .. && \
-                                make"
+                image = docker.build("cmake-build:${env.BUILD_ID}")
 
-                            echo "${platform}: Build Complete!"
-                        }
-                    }
+                stage("Build ${platform}") {
+                    image.inside {
+                        sh "cd firmware && \
+                            rm -rf build_${platform} && \
+                            mkdir build_${platform} && \
+                            cd build_${platform} && \
+                            cmake -DVEHICLE=${platform} -DCMAKE_BUILD_TYPE=Release .. && \
+                            make"
 
-                    stage("Test ${platform} unit tests") {
-                        image.inside {
-                            sh "cd firmware && \
-                                rm -rf build_${platform}_tests && \
-                                mkdir build_${platform}_tests && \
-                                cd build_${platform}_tests && \
-                                cmake -DVEHICLE=${platform} \
-                                  -DTESTS=ON \
-                                  -DPORT_SUFFIX=${EXECUTOR_NUMBER}${platform_idx} \
-                                  -DCMAKE_BUILD_TYPE=Release \
-                                  .. && \
-                                make run-unit-tests"
-                            echo "${platform}: Unit Tests Complete!"
-                        }
-                    }
-
-                    stage("Test ${platform} property-based tests") {
-                        image.inside("--user root:root") {
-                            sh "cd firmware/build_${platform}_tests && \
-                                make run-property-tests"
-                            echo "${platform}: Property-Based Tests Complete!"
-                        }
+                        echo "${platform}: Build Complete!"
                     }
                 }
-                finally {
-                    deleteDir()
+
+                stage("Test ${platform} unit tests") {
+                    image.inside {
+                        sh "cd firmware && \
+                            rm -rf build_${platform}_tests && \
+                            mkdir build_${platform}_tests && \
+                            cd build_${platform}_tests && \
+                            cmake -DVEHICLE=${platform} \
+                              -DTESTS=ON \
+                              -DPORT_SUFFIX=${EXECUTOR_NUMBER}${platform_idx} \
+                              -DCMAKE_BUILD_TYPE=Release \
+                              .. && \
+                            make run-unit-tests"
+                        echo "${platform}: Unit Tests Complete!"
+                    }
+                }
+
+                stage("Test ${platform} property-based tests") {
+                    image.inside("--user root:root") {
+                        sh "cd firmware/build_${platform}_tests && \
+                            make run-property-tests"
+                        echo "${platform}: Property-Based Tests Complete!"
+                    }
                 }
             }
         }


### PR DESCRIPTION
Prior to this commit some builds would fail trying to clean up the workspace
directory. This commit fixes that by removing the inner cleanup since the try
block for the parallel builds should catch any errors from workspace builds.