### PR TITLE
add throttle & speed to obd filters

### DIFF
--- a/firmware/can_gateway/src/communications.cpp
+++ b/firmware/can_gateway/src/communications.cpp
@@ -49,7 +49,9 @@ void republish_obd_frames_to_control_can_bus( void )
     {
         if( (rx_frame.id == KIA_SOUL_OBD_STEERING_WHEEL_ANGLE_CAN_ID)
             || (rx_frame.id == KIA_SOUL_OBD_WHEEL_SPEED_CAN_ID)
-            || (rx_frame.id == KIA_SOUL_OBD_BRAKE_PRESSURE_CAN_ID) )
+            || (rx_frame.id == KIA_SOUL_OBD_BRAKE_PRESSURE_CAN_ID)
+            || (rx_frame.id == KIA_SOUL_OBD_THROTTLE_PRESSURE_CAN_ID)
+            || (rx_frame.id == KIA_SOUL_OBD_SPEED_CAN_ID) )
         {
             cli();
             g_control_can.sendMsgBuf(


### PR DESCRIPTION
This PR adds the throttle pedal position and the vehicle speeds CAN-IDs to the list of diagnostics CAN-IDs that are forward to the control CAN bus.