### PR TITLE
Throttle operator override not being published

### DIFF
--- a/firmware/throttle/src/throttle_control.cpp
+++ b/firmware/throttle/src/throttle_control.cpp
@@ -61,8 +61,7 @@ void check_for_faults( void )
 
             DEBUG_PRINTLN( "Bad value read from accelerator position sensor" );
         }
-        else if ( operator_overridden == true
-          && g_throttle_control_state.operator_override == false )
+        else if ( operator_overridden == true )
         {
             disable_control( );
 


### PR DESCRIPTION
Prior to thie commit the signal, "throttle_operator_override" in the message, "THROTTLE_REPORT(0x93)" did not report a status of driver's throttle override, whereas, the signal, "throttle_report_enabled" in the same message reports properly. The override report signals of steering/brake works well.

The operator override was being generated but not published.

Fix:
Used operator override logic the brake is using.

Verification:
Ran `https://github.com/PolySync/oscc-check/blob/master/oscc-check.py` to enable all modules.  Performed a throttle operator override.

Verified throttle operator overide

```
$ candump can0,093:7FF
  can0  093   [8]  05 CC 01 00 00 B5 08 B8
  can0  093   [8]  05 CC 01 00 00 B5 08 B8
  can0  093   [8]  05 CC 01 00 00 5F 02 1F
  can0  093   [8]  05 CC 00 01 02 B5 08 B8
  can0  093   [8]  05 CC 00 01 02 B5 08 B8
  can0  093   [8]  05 CC 00 01 02 B5 08 B8
```