### PR TITLE
remove speed and throttle pressure CAN IDs

### DIFF
--- a/firmware/can_gateway/src/communications.cpp
+++ b/firmware/can_gateway/src/communications.cpp
@@ -49,9 +49,7 @@ void republish_obd_frames_to_control_can_bus( void )
     {
         if( (rx_frame.id == KIA_SOUL_OBD_STEERING_WHEEL_ANGLE_CAN_ID)
             || (rx_frame.id == KIA_SOUL_OBD_WHEEL_SPEED_CAN_ID)
-            || (rx_frame.id == KIA_SOUL_OBD_BRAKE_PRESSURE_CAN_ID)
-            || (rx_frame.id == KIA_SOUL_OBD_THROTTLE_PRESSURE_CAN_ID)
-            || (rx_frame.id == KIA_SOUL_OBD_SPEED_CAN_ID) )
+            || (rx_frame.id == KIA_SOUL_OBD_BRAKE_PRESSURE_CAN_ID) )
         {
             cli();
             g_control_can.sendMsgBuf(


### PR DESCRIPTION
This PR removes the vehicle speed and throttle pressure forwarding from OSCC, these should be in drivekit.